### PR TITLE
Multi-process cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Features:
   still possible to use the pipe character ("|") in an expression, it
   must now be escaped.
 
+- The template cache can now be shared by multiple processes.
+
 
 2.0-rc3 (2011-03-02)
 --------------------


### PR DESCRIPTION
I created a simple patch that allows multiple processes to share a single Chameleon cache.  This test failed randomly before but now passes with the patch:

rm /tmp/chameleon/\* ; for proc in 1 2 3 4 5 6 7 8 9; do (CHAMELEON_CACHE=/tmp/chameleon bin/python setup.py test & ) ; done
