### PR TITLE
aliases for some common TAL attributes, new test

### DIFF
--- a/src/chameleon/i18n.py
+++ b/src/chameleon/i18n.py
@@ -20,7 +20,7 @@ WHITELIST = frozenset([
     "domain",
     "target",
     "source",
-    "attributes",
+    "attributes", "attr",
     "data",
     "name",
     ])

--- a/src/chameleon/tal.py
+++ b/src/chameleon/tal.py
@@ -49,13 +49,13 @@ ATTR_RE = re.compile(r"\s*([^\s]+)\s+([^\s].*)\Z", re.S)
 ENTITY_RE = re.compile(r'(&(#?)(x?)(\d{1,5}|\w{1,8});)')
 
 WHITELIST = frozenset([
-    "define",
+    "define", "def",
     "comment",
-    "condition",
+    "condition", "if",
     "content",
-    "replace",
-    "repeat",
-    "attributes",
+    "replace", "sub",
+    "repeat", "rep",
+    "attributes", "attr",
     "on-error",
     "omit-tag",
     "script",

--- a/src/chameleon/tests/inputs/120-if.pt
+++ b/src/chameleon/tests/inputs/120-if.pt
@@ -1,0 +1,6 @@
+<html>
+  <body tal:if="True">
+    <span tal:define="selector False" tal:if="selector">bad</span>
+    <span tal:if="True">ok</span>
+  </body>
+</html>

--- a/src/chameleon/tests/inputs/120-if.pt~
+++ b/src/chameleon/tests/inputs/120-if.pt~
@@ -1,0 +1,6 @@
+<html>
+  <body tal:condition="True">
+    <span tal:define="selector False" tal:condition="selector">bad</span>
+    <span tal:condition="True">ok</span>
+  </body>
+</html>

--- a/src/chameleon/tests/inputs/120.xml
+++ b/src/chameleon/tests/inputs/120.xml
@@ -1,0 +1,5 @@
+<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA)>
+<!ENTITY e "">
+]>
+<doc>&e;</doc>

--- a/src/chameleon/tests/inputs/121-def.pt
+++ b/src/chameleon/tests/inputs/121-def.pt
@@ -1,0 +1,6 @@
+<html>
+  <body tal:condition="True">
+    <span tal:def="selector False" tal:condition="selector">bad</span>
+    <span tal:condition="True">ok</span>
+  </body>
+</html>

--- a/src/chameleon/tests/inputs/121-def.pt~
+++ b/src/chameleon/tests/inputs/121-def.pt~
@@ -1,0 +1,6 @@
+<html>
+  <body tal:condition="True">
+    <span tal:define="selector False" tal:condition="selector">bad</span>
+    <span tal:condition="True">ok</span>
+  </body>
+</html>

--- a/src/chameleon/tests/inputs/121.xml
+++ b/src/chameleon/tests/inputs/121.xml
@@ -1,0 +1,5 @@
+<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA)>
+<!ENTITY e "">
+]>
+<doc>&e;</doc>

--- a/src/chameleon/tests/inputs/122-rep.pt
+++ b/src/chameleon/tests/inputs/122-rep.pt
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    <div tal:rep="text ('Hello', 'Goodbye')">
+      <span tal:rep="char ('!', '.')">${text}${char}</span>
+    </div>
+    <tal:check condition="not: exists: text">ok</tal:check>
+  </body>
+</html>

--- a/src/chameleon/tests/inputs/122-rep.pt~
+++ b/src/chameleon/tests/inputs/122-rep.pt~
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    <div tal:repeat="text ('Hello', 'Goodbye')">
+      <span tal:repeat="char ('!', '.')">${text}${char}</span>
+    </div>
+    <tal:check condition="not: exists: text">ok</tal:check>
+  </body>
+</html>

--- a/src/chameleon/tests/inputs/122.xml
+++ b/src/chameleon/tests/inputs/122.xml
@@ -1,0 +1,4 @@
+<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA)>
+]>
+<doc ></doc>

--- a/src/chameleon/tests/inputs/123-sub.pt
+++ b/src/chameleon/tests/inputs/123-sub.pt
@@ -1,0 +1,13 @@
+<html>
+  <body>
+    <div tal:sub="'Hello world!'" />
+    <div tal:sub="'Hello world!'" />1
+   2<div tal:sub="'Hello world!'" />
+    <div tal:sub="'Hello world!'" />3
+    <div tal:sub="'Hello world!'">4</div>5
+   6<div tal:sub="'Hello world!'"></div>
+    <div tal:sub="1" />
+    <div tal:sub="1.0" />
+    <div tal:sub="True" />
+  </body>
+</html>

--- a/src/chameleon/tests/inputs/123-sub.pt~
+++ b/src/chameleon/tests/inputs/123-sub.pt~
@@ -1,0 +1,13 @@
+<html>
+  <body>
+    <div tal:replace="'Hello world!'" />
+    <div tal:replace="'Hello world!'" />1
+   2<div tal:replace="'Hello world!'" />
+    <div tal:replace="'Hello world!'" />3
+    <div tal:replace="'Hello world!'">4</div>5
+   6<div tal:replace="'Hello world!'"></div>
+    <div tal:replace="1" />
+    <div tal:replace="1.0" />
+    <div tal:replace="True" />
+  </body>
+</html>

--- a/src/chameleon/tests/inputs/123.xml
+++ b/src/chameleon/tests/inputs/123.xml
@@ -1,0 +1,4 @@
+<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA)>
+]>
+<doc><![CDATA[<&]]></doc>

--- a/src/chameleon/tests/inputs/124-attr.pt
+++ b/src/chameleon/tests/inputs/124-attr.pt
@@ -1,0 +1,13 @@
+<html>
+  <body>
+    <span tal:attr="class 'hello'" />
+    <span tal:attr="class None" />
+    <span a="1" b="2" c="3" tal:attr="a None" />
+    <span a="1" b="2" c="3" tal:attr="b None" />
+    <span a="1" b="2" c="3" tal:attr="c None" />
+    <span a="1" b="2" c="3" tal:attr="b None; c None" />
+    <span a="1" b="2" c="3" tal:attr="b string:;;" />
+    <span a="1" b="2" c="3" tal:attr="b string:&amp;" />
+    <span class="hello" tal:attr="class 'goodbye'" />
+  </body>
+</html>

--- a/src/chameleon/tests/inputs/124-attr.pt~
+++ b/src/chameleon/tests/inputs/124-attr.pt~
@@ -1,0 +1,13 @@
+<html>
+  <body>
+    <span tal:attributes="class 'hello'" />
+    <span tal:attributes="class None" />
+    <span a="1" b="2" c="3" tal:attributes="a None" />
+    <span a="1" b="2" c="3" tal:attributes="b None" />
+    <span a="1" b="2" c="3" tal:attributes="c None" />
+    <span a="1" b="2" c="3" tal:attributes="b None; c None" />
+    <span a="1" b="2" c="3" tal:attributes="b string:;;" />
+    <span a="1" b="2" c="3" tal:attributes="b string:&amp;" />
+    <span class="hello" tal:attributes="class 'goodbye'" />
+  </body>
+</html>

--- a/src/chameleon/tests/inputs/124.xml
+++ b/src/chameleon/tests/inputs/124.xml
@@ -1,0 +1,5 @@
+<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA)>
+<!ATTLIST doc a1 CDATA #IMPLIED>
+]>
+<doc a1="v1"></doc>

--- a/src/chameleon/tests/inputs/125-i18n-attr.pt
+++ b/src/chameleon/tests/inputs/125-i18n-attr.pt
@@ -1,0 +1,11 @@
+<html>
+  <body>
+    <div i18n:translate="" tal:content="string:Hello world!">
+      Hello world!
+    </div>
+    <img alt="${'Hello world!'}" i18n:attributes="alt" />
+    <img alt="${'Hello world!'}" i18n:attributes="alt hello_world" />
+    <img tal:attributes="alt 'Hello world!'" i18n:attributes="alt" />
+    <img tal:attributes="alt 'Hello world!'" i18n:attributes="alt hello_world" />
+  </body>
+</html>

--- a/src/chameleon/tests/inputs/125.xml
+++ b/src/chameleon/tests/inputs/125.xml
@@ -1,0 +1,4 @@
+<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA)>
+]>
+<doc><?pi?></doc>

--- a/src/chameleon/tests/outputs/120.pt
+++ b/src/chameleon/tests/outputs/120.pt
@@ -1,0 +1,6 @@
+<html>
+  <body>
+
+    <span>ok</span>
+  </body>
+</html>

--- a/src/chameleon/tests/outputs/121.pt
+++ b/src/chameleon/tests/outputs/121.pt
@@ -1,0 +1,6 @@
+<html>
+  <body>
+
+    <span>ok</span>
+  </body>
+</html>

--- a/src/chameleon/tests/outputs/122.pt
+++ b/src/chameleon/tests/outputs/122.pt
@@ -1,0 +1,13 @@
+<html>
+  <body>
+    <div>
+      <span>Hello!</span>
+      <span>Hello.</span>
+    </div>
+    <div>
+      <span>Goodbye!</span>
+      <span>Goodbye.</span>
+    </div>
+    ok
+  </body>
+</html>

--- a/src/chameleon/tests/outputs/123.pt
+++ b/src/chameleon/tests/outputs/123.pt
@@ -1,0 +1,13 @@
+<html>
+  <body>
+    Hello world!
+    Hello world!1
+   2Hello world!
+    Hello world!3
+    Hello world!5
+   6Hello world!
+    1
+    1.0
+    True
+  </body>
+</html>

--- a/src/chameleon/tests/outputs/124.pt
+++ b/src/chameleon/tests/outputs/124.pt
@@ -1,0 +1,13 @@
+<html>
+  <body>
+    <span class="hello" />
+    <span />
+    <span b="2" c="3" />
+    <span a="1" c="3" />
+    <span a="1" b="2" />
+    <span a="1" />
+    <span a="1" b=";" c="3" />
+    <span a="1" b="&amp;" c="3" />
+    <span class="goodbye" />
+  </body>
+</html>

--- a/src/chameleon/tests/outputs/125.pt
+++ b/src/chameleon/tests/outputs/125.pt
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <div>Hello world!</div>
+    <img alt="Hello world!" />
+    <img alt="Hello world!" />
+    <img alt="Hello world!" />
+    <img alt="Hello world!" />
+  </body>
+</html>

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -219,6 +219,16 @@ class ZopePageTemplatesTest(RenderTestCase):
             string.replace('${text}', text)
             )
 
+    def test_dont_interpolate_comments(self):
+        string = '<!-- ${nonexistentVariable} -->'
+
+        template = self.factory(string)
+        rendered = template()
+
+        self.assertEqual(
+            rendered, string
+            )
+
     def test_repr(self):
         from chameleon.zpt.template import PageTemplateFile
         template = PageTemplateFile(

--- a/src/chameleon/zpt/program.py
+++ b/src/chameleon/zpt/program.py
@@ -192,19 +192,27 @@ class MacroProgram(ElementProgram):
                     content = nodes.Translate(clause, content)
 
             # tal:attributes
-            try:
+            clause = None
+            if (TAL, 'attributes') in ns:
                 clause = ns[TAL, 'attributes']
-            except KeyError:
-                TAL_ATTRIBUTES = {}
+            elif (TAL, 'attr') in ns:
+                clause = ns[TAL, 'attr']
             else:
+                TAL_ATTRIBUTES = {}
+
+            if clause:
                 TAL_ATTRIBUTES = tal.parse_attributes(clause)
 
             # i18n:attributes
-            try:
+            clause = None
+            if (I18N, 'attributes') in ns:
                 clause = ns[I18N, 'attributes']
-            except KeyError:
-                I18N_ATTRIBUTES = {}
+            elif (I18N, 'attr') in ns:
+                clause = ns[I18N, 'attr']
             else:
+                I18N_ATTRIBUTES = {}
+
+            if clause:
                 I18N_ATTRIBUTES = i18n.parse_attributes(clause)
 
             # Prepare attributes from TAL language
@@ -272,11 +280,15 @@ class MacroProgram(ElementProgram):
                     inner = nodes.Cache([omit], inner)
 
             # tal:replace
-            try:
+            clause = None
+            if (TAL, 'replace') in ns:
                 clause = ns[TAL, 'replace']
-            except KeyError:
-                pass
+            elif (TAL, 'sub') in ns:
+                clause = ns[TAL, 'sub']
             else:
+                DEFINE = skip
+
+            if clause:
                 key, value = tal.parse_substitution(clause)
                 value = unescape(value)
                 expression = nodes.Expression(value)
@@ -292,11 +304,15 @@ class MacroProgram(ElementProgram):
             DEFINE_SLOT = partial(nodes.DefineSlot, clause)
 
         # tal:define
-        try:
+        clause = None
+        if (TAL, 'define') in ns:
             clause = ns[TAL, 'define']
-        except KeyError:
-            DEFINE = skip
+        elif (TAL, 'def') in ns:
+            clause = ns[TAL, 'def']
         else:
+            DEFINE = skip
+
+        if clause:
             defines = tal.parse_defines(clause)
             if defines is None:
                 raise ParseError("Invalid define syntax.", clause)
@@ -331,12 +347,16 @@ class MacroProgram(ElementProgram):
                     )
                 )
 
-        # tal:repeat
-        try:
+        # tal:repeat and tal:rep
+        clause = None
+        if (TAL, 'repeat') in ns:
             clause = ns[TAL, 'repeat']
-        except KeyError:
-            REPEAT = skip
+        elif (TAL, 'rep') in ns:
+            clause = ns[TAL, 'rep']
         else:
+            REPEAT = skip
+
+        if clause:
             defines = tal.parse_defines(clause)
             assert len(defines) == 1
             context, names, expr = defines[0]
@@ -351,12 +371,16 @@ class MacroProgram(ElementProgram):
                 whitespace
                 )
 
-        # tal:condition
-        try:
+        # tal:condition and tal:if
+        clause = None
+        if (TAL, 'condition') in ns:
             clause = ns[TAL, 'condition']
-        except KeyError:
-            CONDITION = skip
+        elif (TAL, 'if') in ns:
+            clause = ns[TAL, 'if']
         else:
+            CONDITION = skip
+
+        if clause:
             expression = nodes.Expression(clause)
             CONDITION = partial(nodes.Condition, expression)
 


### PR DESCRIPTION
1) created a test to make sure that interpolation doesn't occur within HTML comments, i.e.
   <!-- ${nonexistentVariable} --> renders to itself.
2) created shorter aliases for many of the most common TAL attributes, namely:
   "def" is an alias for "define",
   "if" for "condition",
   "sub" for "replace",
   "rep" for "repeat"
   "attr" for "attributes"
3) for uniformity, also created an alias "attr" for "attributes" in the I18N namespace.

thanks
