### PR TITLE
tox testing...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 *.pyc
+*.egg
+*.egg-info
+.coverage
+.tox/
+coverage.xml
+nosetests.xml
+*.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,22 @@ __version__ = '2.0-rc6'
 import os
 import sys
 
-from distribute_setup import use_setuptools
-use_setuptools()
+try:
+    from distribute_setup import use_setuptools
+    use_setuptools()
+except: # doesn't work under tox/pip
+    pass
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test
 
 here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.rst')).read()
-CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
+try:
+    README = open(os.path.join(here, 'README.rst')).read()
+    CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
+except: # doesn't work under tox/pip
+    README = ''
+    CHANGES = ''
 
 install_requires = []
 

--- a/src/chameleon/tests/test_parser.py
+++ b/src/chameleon/tests/test_parser.py
@@ -1,3 +1,5 @@
+from __future__ import with_statement
+
 import sys
 
 from unittest import TestCase

--- a/src/chameleon/tests/test_sniffing.py
+++ b/src/chameleon/tests/test_sniffing.py
@@ -1,3 +1,5 @@
+from __future__ import with_statement
+
 import os
 import unittest
 import tempfile

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import with_statement
+
 import re
 import os
 import sys
@@ -284,7 +286,7 @@ class ZopeTemplatesTestSuite(RenderTestCase):
         from chameleon.loader import TemplateLoader
         loader = TemplateLoader(os.path.join(self.root, "inputs"))
 
-        self.run_tests(
+        self.execute(
             ".pt", PageTemplate,
             literal=Literal("<div>Hello world!</div>"),
             content="<div>Hello world!</div>",
@@ -294,9 +296,9 @@ class ZopeTemplatesTestSuite(RenderTestCase):
 
     def test_txt_files(self):
         from ..zpt.template import PageTextTemplate
-        self.run_tests(".txt", PageTextTemplate)
+        self.execute(".txt", PageTextTemplate)
 
-    def run_tests(self, ext, factory, **kwargs):
+    def execute(self, ext, factory, **kwargs):
         from chameleon.utils import DebuggingOutputStream
 
         def translate(msgid, domain=None, mapping=None, context=None,

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,47 @@
+[tox]
+envlist = 
+    py25,py26,py27,pypy,cover
+
+[testenv:py25]
+commands = 
+   python setup.py test -q
+deps = 
+    ordereddict
+    unittest2
+    distribute
+
+[testenv:py26]
+commands = 
+   python setup.py test -q
+deps = 
+    ordereddict
+    unittest2
+    distribute
+
+[testenv:py27]
+commands = 
+   python setup.py test -q
+deps = 
+    distribute
+
+[testenv:pypy]
+commands = 
+   python setup.py test -q
+deps = 
+    ordereddict
+    unittest2
+    distribute
+
+[testenv:cover]
+basepython =
+    python2.6
+commands = 
+    python setup.py nosetests --with-xunit --with-xcoverage
+deps =
+    nose
+    coverage
+    nosexcover
+    ordereddict
+    unittest2
+    distribute
+


### PR DESCRIPTION
Hi Malthe,

This pull request implies changes to Chameleon which allows for "tox" testing.  Once merged, Chameleon can be tested on Py 2.5, 2.6, 2.7, and PyPy via:

```
tox
```

This will allow us to add it to the Jenkins configuration on http://jenkins.repoze.org
