### PR TITLE
tox.ini fixes for jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 coverage.xml
 nosetests.xml
 *.tar.gz
+env25/
+env26/
+env27/
+env32/

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = 
-    py25,py26,py27,pypy,cover
+    py25,py26,py27,py32,pypy,cover
 
 [testenv:py25]
 commands = 
@@ -24,6 +24,12 @@ commands =
 deps = 
     distribute
 
+[testenv:py32]
+commands = 
+   python setup.py test -q
+deps = 
+    distribute
+
 [testenv:pypy]
 commands = 
    python setup.py test -q
@@ -39,7 +45,7 @@ commands =
     python setup.py nosetests --with-xunit --with-xcoverage
 deps =
     nose
-    coverage
+    coverage==3.4
     nosexcover
     ordereddict
     unittest2


### PR DESCRIPTION
make coverage work again for recent nosexcover in tox.ini

add py32 to tox.ini

add convenience ignores for environments in package
