### PR TITLE
i18n translations don't work on Python 2.5.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Bugfixes:
   and hyphens are replaced by an underscore). This fixes issue #17.
   [malthe]
 
+- i18n translations didn't work on Python 2.5.
+
 2.0 (2011-07-14)
 ----------------
 

--- a/src/chameleon/zpt/template.py
+++ b/src/chameleon/zpt/template.py
@@ -15,10 +15,14 @@ from ..template import BaseTemplateFile
 from .program import MacroProgram as Program
 
 try:
+    bytes
+except NameError:
+    bytes = str
+
+try:
     str = unicode
 except NameError:
     pass
-
 
 class PageTemplate(BaseTemplate):
     """Template class for the Chameleon Page Templates language.


### PR DESCRIPTION
This fixes it.  It really should have test coverage, I guess.
