### PR TITLE
Bug fix for unicode whitespace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Unreleased
+----------
+
+Bugfixes:
+
+- In certain circumstances, a Unicode non-breaking space character would cause
+  a define clause to fail to parse.
+
 2.7.1 (2011-12-29)
 ------------------
 


### PR DESCRIPTION
Hi Malthe, 

We're in the process of converting Karl to use Chameleon 2 and one thing I stumbled upon was he have one template that somehow got a non-breaking space character (Unicode 160) in a define clause, which was causing the define clause to fail to parse.  Although, I'm just going to edit our template so it works with existing code, in the process of figuring out what was going on I figured out a fix for the Chameleon side of things that would make it more resilient in the future.  Basically, when compiling the regular expression you can just pass in the re.UNICODE flag, which will expand its understanding of which characters are white space.  I added the flag to a few likely looking regular expressions and added test coverage for the parse_defines function.
