### PR TITLE
Fix a BytesWarning when running tests via python -b on Python 3.2

### DIFF
--- a/src/chameleon/utils.py
+++ b/src/chameleon/utils.py
@@ -127,7 +127,7 @@ def read_bytes(body, default_encoding):
             return document, encoding, \
                    "text/xml" if document.startswith("<?xml") else None
 
-        if prefix != '<?xml' and body.startswith(prefix):
+        if prefix != b'<?xml' and body.startswith(prefix):
             return body.decode(encoding), encoding, "text/xml"
 
     if body.startswith(_xml_decl):


### PR DESCRIPTION
Before this patch:

```

[chrism@thinko chameleon]$ env32/bin/python -b setup.py test -q
running test
running egg_info
writing src/Chameleon.egg-info/PKG-INFO
writing top-level names to src/Chameleon.egg-info/top_level.txt
writing dependency_links to src/Chameleon.egg-info/dependency_links.txt
reading manifest file 'src/Chameleon.egg-info/SOURCES.txt'
writing manifest file 'src/Chameleon.egg-info/SOURCES.txt'
running build_ext
/home/chrism/projects/chameleon/chameleon/src/chameleon/utils.py:130: BytesWarning: Comparison between bytes and string
  if prefix != '<?xml' and body.startswith(prefix):
....................................................................
----------------------------------------------------------------------
Ran 68 tests in 3.565s

OK
```

`-b` means show warnings when comparing `bytes` to `str`.
