### PR TITLE
Allow zope.i18n.translate() to find a language from the HTTP request

### DIFF
--- a/src/chameleon/i18n.py
+++ b/src/chameleon/i18n.py
@@ -66,7 +66,7 @@ else:   # pragma: no cover
         if msgid is None:
             return
 
-        if target_language is not None:
+        if target_language is not None or context is not None:
             result = translate(
                 msgid, domain=domain, mapping=mapping, context=context,
                 target_language=target_language, default=default)


### PR DESCRIPTION
zope.i18n.translate() can find a language to translate messages into,
either from a specific language, or detecting the preferred language of
the user from the HTTP request.

This changeset gives access to the HTTP request to the translation
framework, as zope.pagetemplate does
http://zope3.pov.lt/trac/browser/zope.pagetemplate/tags/3.6.3/src/zope/pagetemplate/engine.py#L106

Fixes #93

I'm trying to use Chameon instead of zope.tal/zope.tales in a Zope 3/ZTK application, and as a drop-in replacement, using z3c.pt and z3c.ptcompat, I couldn't get the translation to work again.
Basically, the language is not known in fast_translate() because [z3c.pt calls zope.i18n.negotiate()](http://zope3.pov.lt/trac/browser/z3c.pt/tags/2.2.1/src/z3c/pt/pagetemplate.py#L119), which looks for language in the [OS environment variable "zope_i18n_allowed_languages"](http://zope3.pov.lt/trac/browser/zope.i18n/tags/3.8.0/src/zope/i18n/__init__.py#L35)

Thanks for considering merging this.
