### PR TITLE
Fix installation errors in Python 3

### DIFF
--- a/src/chameleon/benchmark.py
+++ b/src/chameleon/benchmark.py
@@ -2,6 +2,7 @@ import unittest
 import time
 import os
 import re
+from .utils import text_
 
 re_amp = re.compile(r'&(?!([A-Za-z]+|#[0-9]+);)')
 
@@ -367,7 +368,7 @@ class Benchmarks(unittest.TestCase):
         template.pt_edit(body, 'text/xhtml')
         return template
 
-    @benchmark(u"BIGTABLE [python]")
+    @benchmark(text_("BIGTABLE [python]"))
     def test_bigtable(self):
         options = {'table': self.table}
 
@@ -401,7 +402,7 @@ class Benchmarks(unittest.TestCase):
             len(self._zope(BIGTABLE_ZPT)(table=self.table))))
         print("--------------------------")
 
-    @benchmark(u"MANY STRINGS [python]")
+    @benchmark(text_("MANY STRINGS [python]"))
     def test_many_strings(self):
         t_chameleon = timing(self._chameleon(MANY_STRINGS_ZPT))
         print("chameleon:         %7.2f" % t_chameleon)
@@ -415,7 +416,7 @@ class Benchmarks(unittest.TestCase):
             len(self._zope(MANY_STRINGS_ZPT)())))
         print("--------------------------")
 
-    @benchmark(u"HELLO WORLD")
+    @benchmark(text_("HELLO WORLD"))
     def test_hello_world(self):
         t_chameleon = timing(self._chameleon(HELLO_WORLD_ZPT)) * 1000
         print("chameleon:         %7.2f" % t_chameleon)
@@ -429,7 +430,7 @@ class Benchmarks(unittest.TestCase):
             len(self._zope(HELLO_WORLD_ZPT)())))
         print("--------------------------")
 
-    @benchmark(u"I18N")
+    @benchmark(text_("I18N"))
     def test_i18n(self):
         from zope.i18n import translate
         t_chameleon = timing(
@@ -441,7 +442,7 @@ class Benchmarks(unittest.TestCase):
         print("zope.pagetemplate: %7.2f" % t_zope)
         print("                  %7.1fX" % (t_zope / t_chameleon))
 
-    @benchmark(u"COMPILATION")
+    @benchmark(text_("COMPILATION"))
     def test_compilation(self):
         template = self._chameleon(HELLO_WORLD_ZPT)
 

--- a/src/chameleon/py25.py
+++ b/src/chameleon/py25.py
@@ -1,7 +1,10 @@
+import sys
+
 def lookup_attr(obj, key):
     try:
         return getattr(obj, key)
-    except AttributeError, exc:
+    except AttributeError:
+        exc = sys.exc_info()[1]
         try:
             get = obj.__getitem__
         except AttributeError:
@@ -11,9 +14,22 @@ def lookup_attr(obj, key):
         except KeyError:
             raise exc
 
+def exec_(code, globs=None, locs=None):
+    """Execute code in a namespace."""
+    if globs is None:
+        frame = sys._getframe(1)
+        globs = frame.f_globals
+        if locs is None:
+            locs = frame.f_locals
+        del frame
+    elif locs is None:
+        locs = globs
+    exec("""exec code in globs, locs""")
 
-def raise_with_traceback(exc, tb):
+
+exec_("""def raise_with_traceback(exc, tb):
     raise type(exc), exc, tb
+""")
 
 
 def next(iter):

--- a/src/chameleon/utils.py
+++ b/src/chameleon/utils.py
@@ -72,6 +72,12 @@ else:
         exc.__traceback__ = tb
         raise exc
 
+def text_(s, encoding='latin-1', errors='strict'):
+    """ If ``s`` is an instance of ``binary_type``, return
+    ``s.decode(encoding, errors)``, otherwise return ``s``"""
+    if isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    return s
 
 entity_re = re.compile(r'&(#?)(x?)(\d{1,5}|\w{1,8});')
 


### PR DESCRIPTION
These changes fix issue #94.  Tested with python setup.py install and python setup.py test -q in Python 2.6, 2.7 and 3.2; using Ubuntu 11.10.
