### PR TITLE
Fix py25 install

### DIFF
--- a/src/chameleon/py26.py
+++ b/src/chameleon/py26.py
@@ -1,7 +1,10 @@
+import sys
+
 def lookup_attr(obj, key):
     try:
         return getattr(obj, key)
-    except AttributeError as exc:
+    except AttributeError:
+        exc = sys.exc_info()[1]
         try:
             get = obj.__getitem__
         except AttributeError:


### PR DESCRIPTION
Hi Malthe,

I finally was able to use the pip install and python setup.py test -q commands with Python 2.5 (first I solved some errors in building Python 2.5 from the sources caused by two missing compiler flags required in Ubuntu).  Re-tested these changes in py26, py27 and py32 ok.

Regards,
Patricio
