### PR TITLE
Compiler.py to pass econtext to tranlator()

### DIFF
--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -344,7 +344,7 @@ class Interpolator(object):
 
             if translate and isinstance(target, ast.Str):
                 target = template(
-                    "translate(msgid, domain=__i18n_domain)",
+                    "translate(msgid, domain=__i18n_domain, context=econtext)",
                     msgid=target, mode="eval",
                     )
         else:
@@ -363,7 +363,7 @@ class Interpolator(object):
                         values.append(node)
 
                 target = template(
-                    "translate(msgid, mapping=mapping, domain=__i18n_domain)",
+                    "translate(msgid, mapping=mapping, domain=__i18n_domain, context=econtext)",
                     msgid=ast.Str(s=formatting_string),
                     mapping=ast.Dict(keys=keys, values=values),
                     mode="eval"
@@ -1230,7 +1230,7 @@ class Compiler(object):
         # emit the translation expression
         body += template(
             "__append(translate("
-            "msgid, mapping=mapping, default=default, domain=__i18n_domain))",
+            "msgid, mapping=mapping, default=default, domain=__i18n_domain, context=econtext))",
             msgid=msgid, default=default, mapping=mapping
             )
 


### PR DESCRIPTION
This is a change to fix Pyramid's issue in  translator() as it only gets text string but no "context". It would call get_current_request() to get the 'request' which is not green thread safe. This patch will provide the translate a context to pass to translator().
