### PR TITLE
Make it more obvious that the location gives line/column

### DIFF
--- a/src/chameleon/exc.py
+++ b/src/chameleon/exc.py
@@ -258,7 +258,7 @@ class ExceptionFormatter(object):
 
             out.append(" - Expression: \"%s\"" % expression)
             out.append(" - Filename:   %s" % _filename)
-            out.append(" - Location:   (line %d: col%d)" % (line, column))
+            out.append(" - Location:   (line %d: col %d)" % (line, column))
 
             if filename and line and column:
                 try:

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -362,7 +362,7 @@ class ZopePageTemplatesTest(RenderTestCase):
             formatted = str(exc)
             self.assertFalse('NameError:' in formatted)
             self.assertTrue('foo' in formatted)
-            self.assertTrue('(1:23)' in formatted)
+            self.assertTrue('(line 1: col 23)' in formatted)
 
             formatted_exc = "\n".join(format_exception_only(type(exc), exc))
             self.assertTrue('NameError: foo' in formatted_exc)
@@ -419,7 +419,7 @@ class ZopePageTemplatesTest(RenderTestCase):
             formatted = str(exc)
             self.assertTrue('TestException' in formatted)
             self.assertTrue('"expression"' in formatted)
-            self.assertTrue('(1:42)' in formatted)
+            self.assertTrue('(line 1: col 42)' in formatted)
         else:
             self.fail("unexpected error")
 


### PR DESCRIPTION
I've heard a few people complain that they don't understand Chameleon's tracebacks and I think this could help.
