### PR TITLE
keep token location information in exception rendering

### DIFF
--- a/src/chameleon/exc.py
+++ b/src/chameleon/exc.py
@@ -134,6 +134,7 @@ class TemplateError(Exception):
         self.token = safe_native(token)
         self.offset = getattr(token, "pos", 0)
         self.filename = token.filename
+        self.location = token.location
 
     def __copy__(self):
         inst = Exception.__new__(type(self))
@@ -151,13 +152,9 @@ class TemplateError(Exception):
             text += "\n"
             text += " - Filename:   %s" % self.filename
 
-        try:
-            line, column = self.token.location
-        except AttributeError:
-            pass
-        else:
-            text += "\n"
-            text += " - Location:   (line %d: col %d)" % (line, column)
+        line, column = self.location
+        text += "\n"
+        text += " - Location:   (line %d: col %d)" % (line, column)
 
         return text
 

--- a/src/chameleon/tests/test_exc.py
+++ b/src/chameleon/tests/test_exc.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+
+class TestTemplateError(TestCase):
+
+    def test_keep_token_location_info(self):
+        # tokens should not lose information when passed to a TemplateError
+        from chameleon import exc, tokenize, utils
+        token = tokenize.Token('stuff', 5, 'more\nstuff', 'mystuff.txt')
+        error = exc.TemplateError('message', token)
+        s = str(error)
+        self.assertTrue(
+                '- Location:   (line 2: col 0)' in s,
+                'No location data found\n%s' % s)


### PR DESCRIPTION
This was getting lost because safe_native converts
the token to a string. The result is indecipherable
ParseErrors. Like this: 

  File "/Users/jinty/py/py27/lib/python2.7/site-packages/chameleon/parser.py", line 234, in visit_end_tag
    raise ParseError("Unexpected end tag.", token)
chameleon.exc.ParseError: Unexpected end tag.
- String:     "</div>"
- Filename:   /some/path/template.pt
