### PR TITLE
Add MANIFEST.in to guarantee installing package data.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include src/chameleon/tests/inputs *
+recursive-include src/chameleon/tests/outputs *


### PR DESCRIPTION
I am one of the people responsible for packaging Python packages in Gentoo and we have a bit of problem packaging Chameleon.

Chameleon seems to rely on a fragile feature of setuptools that automatically installs package data files from Python source directories. This affects the `tests/inputs` and `tests/outputs` directories.

Sadly, for this feature to work properly either:
1. Chameleon must be built from a complete git checkout and `setuptools-git` must be installed,
2. A pre-generated egg-info (bundled in tarball) must be used.

Sadly, (2) becomes a real problem when source tree is shared. Since setuptools write to egg-info directory, we have to override its location to a local copy. But then, setuptools no longer finds the original egg-info. As a result, Chameleon is installed without package data files.

Could you please consider listing the package data files in `MANIFEST.in` instead? This 'older' way is far safer and more compatible.

Unless we're missing something, adding the `MANIFEST.in` as attached should fix the issue for us, improve general compatibility of the code and introduce no regressions.
