### PR TITLE
RepeatDict raises KeyError on getattr for missing attrs (which breaks zope.interface on PyPy)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Bugfixes:
   loader is garbage-collected (on ``__del__``).
   [graffic]
 
+- Using the three-argument form of ``getattr`` on a
+  ``chameleon.tal.RepeatDict`` no longer raises ``KeyError``,
+  letting the default provided to ``getattr`` be used. This fixes
+  attempting to adapt a ``RepeatDict`` to a Zope interface under
+  PyPy.
 
 2.12 (2013-03-26)
 -----------------

--- a/src/chameleon/tal.py
+++ b/src/chameleon/tal.py
@@ -427,14 +427,33 @@ class RepeatDict(dict):
     >>> repeat['numbers']
     <chameleon.tal.RepeatItem object at ...>
 
-    """
+    >>> repeat.numbers
+    <chameleon.tal.RepeatItem object at ...>
 
-    __slots__ = "__setitem__", "__getitem__", "__getattr__"
+    >>> getattr(repeat, 'missing_key', None) is None
+    True
+
+	>>> try:
+	...     import interfaces
+	...     interfaces.ITALESIterator(repeat,None) is None
+	... except ImportError:
+	...     True
+	...
+	True
+	"""
+
+    __slots__ = "__setitem__", "__getitem__"
 
     def __init__(self, d):
         self.__setitem__ = d.__setitem__
         self.__getitem__ = d.__getitem__
-        self.__getattr__ = d.__getitem__
+
+    def __getattr__(self,key):
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
+
 
     def __call__(self, key, iterable):
         """We coerce the iterable to a tuple and return an iterator

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ deps =
     ordereddict
     unittest2
     distribute
+    zope.interface
 
 [testenv:cover]
 basepython =


### PR DESCRIPTION
The class `chameleon.tal.RepeatDict` copies `dict`s version of `__getitem__` directly into its `__getattr__` function. Doing so causes problems for missing attributes because, while `__getitem__` is supposed to raise `KeyError`, `__getattr__` is supposed to raise `AttributeError`. This commit makes `__getattr__` do the expected thing.

When Python's `getattr` function is called with three arguments to provide a default value for missing attributes, it catches `AttributeError` but allows `KeyError` to pass through. Before this commit this caused the default to be ignored and the caller to deal with an unexpected exception. 

One practical place this was a problem was in using Chameleon under PyPy. We use Chameleon with the Zope traversal model, which uses Zope interfaces, and under PyPy `zope.interface` is implemented in Python code making heavy use of `getattr`. With `getattr` throwing `KeyError`, interface adaptation was broken:

```
File ".../chameleon/src/chameleon/tal.py", line 433, in chameleon.tal.RepeatDict
Failed example:

    import interfaces
    interfaces.ITALESIterator(repeat,None) is None

Exception raised:
Traceback (most recent call last):
  File "<doctest chameleon.tal.RepeatDict[5]>", line 3, in <module>
    interfaces.ITALESIterator(repeat,None) is None
  File ".../zope.interface-4.0.5-py2.7.egg/zope/interface/interface.py", line 129, in __call__
    conform = getattr(obj, '__conform__', None)
KeyError: '__conform__'
```
