### PR TITLE
Support for Python 3.4's NameConstant in AST

### DIFF
--- a/src/chameleon/astutil.py
+++ b/src/chameleon/astutil.py
@@ -914,6 +914,9 @@ class ASTCodeGenerator(object):
             self._write(', ')
         self._write(')')
 
+    # NameConstant(singleton value)
+    def visit_NameConstant(self, node):
+        self._write(str(node.value))
 
 class AnnotationAwareVisitor(ast.NodeVisitor):
     def visit(self, node):


### PR DESCRIPTION
Python 3.4 adds a new NameConstant AST node type, representing
a None, False or True literal.

This change adds support for the new node type.

Fixes #168
