### PR TITLE
Expressions for bare HTML attributes break evaluation

### DIFF
--- a/src/chameleon/tests/inputs/092-char-suffix.pt
+++ b/src/chameleon/tests/inputs/092-char-suffix.pt
@@ -1,13 +1,6 @@
 <html>
-<body tal:define="tavarat [{'id':1, 'koodi': '456', 'nimi': 'DEF', 'hinta': '32.0', 'maara': '23', 'tyyppi': 'AT'},
-                           {'id':1, 'koodi': '456', 'nimi': 'DEF', 'hinta': '32.0', 'maara': '23', 'tyyppi': 'AT'}]">
-    <tr tal:repeat="tavara tavarat">
-        <td class="tavara_col1"><input name="${tavara.id}-koodi" value="${tavara.koodi}"></td>
-        <td class="tavara_col2"><input name="${tavara.id}-nimi" value="${tavara.nimi}"></td>
-        <td class="tavara_col3"><input name="${tavara.id}-hinta" value="${tavara.hinta}"></td>
-        <td class="tavara_col4"><input name="${tavara.id}-maara" value="${tavara.maara}"></td>
-        <td class="tavara_col5"><input name="${tavara.id}-A" type="checkbox" ${'checked' if 'A' in tavara.tyyppi else ''}></td>
-        <td class="tavara_col6"><input name="${tavara.id}-T" type="checkbox" ${'checked' if 'T' in tavara.tyyppi else ''}></td>
-    </tr>
+  <body>
+    <input name="${'foo'}" type="checkbox" ${'checked' if True else ''}>
+    <input name="${'foo'}" type="checkbox" checked="${'checked' if True else ''}">
   </body>
 </html>

--- a/src/chameleon/tests/outputs/092.pt
+++ b/src/chameleon/tests/outputs/092.pt
@@ -1,20 +1,6 @@
 <html>
-<body>
-    <tr>
-        <td class="tavara_col1"><input name="1-koodi" value="456"></td>
-        <td class="tavara_col2"><input name="1-nimi" value="DEF"></td>
-        <td class="tavara_col3"><input name="1-hinta" value="32.0"></td>
-        <td class="tavara_col4"><input name="1-maara" value="23"></td>
-        <td class="tavara_col5"><input name="1-A" type="checkbox" checked></td>
-        <td class="tavara_col6"><input name="1-T" type="checkbox" checked></td>
-    </tr>
-    <tr>
-        <td class="tavara_col1"><input name="1-koodi" value="456"></td>
-        <td class="tavara_col2"><input name="1-nimi" value="DEF"></td>
-        <td class="tavara_col3"><input name="1-hinta" value="32.0"></td>
-        <td class="tavara_col4"><input name="1-maara" value="23"></td>
-        <td class="tavara_col5"><input name="1-A" type="checkbox" checked></td>
-        <td class="tavara_col6"><input name="1-T" type="checkbox" checked></td>
-    </tr>
+  <body>
+    <input name="foo" type="checkbox" checked>
+    <input name="foo" type="checkbox" checked="checked">
   </body>
 </html>


### PR DESCRIPTION
This was reported on #pyramid by varesa. I haven't figured out why this breaks, but the tests do show the failure:

```
Expected:
    <html>
      <body>
        <input name="1" type="checkbox" checked>
        <input name="1" type="checkbox" checked="checked">
      </body>
    </html>
Got:
    <html>
      <body>
        <input name="${'foo'}" type="checkbox" checked>
        <input name="foo" type="checkbox" checked="checked">
      </body>
    </html>
```
