### PR TITLE
Don't modify environment when getting variables from it.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ In next release ...
 - Add missing 'parity' repeat property.
   [voxspox]
 
+- Don't modify environment when getting variables from it.
+  [fschulze]
+
 
 2.16 (2014-05-06)
 -----------------

--- a/src/chameleon/config.py
+++ b/src/chameleon/config.py
@@ -9,7 +9,7 @@ TRUE = ('y', 'yes', 't', 'true', 'on', '1')
 # If eager parsing is enabled, templates are parsed upon
 # instantiation, rather than when first called upon; this mode is
 # useful for verifying validity of templates across a project
-EAGER_PARSING = os.environ.pop('CHAMELEON_EAGER', 'false')
+EAGER_PARSING = os.environ.get('CHAMELEON_EAGER', 'false')
 EAGER_PARSING = EAGER_PARSING.lower() in TRUE
 
 # Debug mode is mostly useful for debugging the template engine
@@ -18,12 +18,12 @@ EAGER_PARSING = EAGER_PARSING.lower() in TRUE
 # output. Also, the generated source code is available in the
 # ``source`` attribute of the template instance if compilation
 # succeeded.
-DEBUG_MODE = os.environ.pop('CHAMELEON_DEBUG', 'false')
+DEBUG_MODE = os.environ.get('CHAMELEON_DEBUG', 'false')
 DEBUG_MODE = DEBUG_MODE.lower() in TRUE
 
 # If a cache directory is specified, template source code will be
 # persisted on disk and reloaded between sessions
-path = os.environ.pop('CHAMELEON_CACHE', None)
+path = os.environ.get('CHAMELEON_CACHE', None)
 if path is not None:
     CACHE_DIRECTORY = os.path.abspath(path)
     if not os.path.exists(CACHE_DIRECTORY):
@@ -35,7 +35,7 @@ else:
     CACHE_DIRECTORY = None
 
 # When auto-reload is enabled, templates are reloaded on file change.
-AUTO_RELOAD = os.environ.pop('CHAMELEON_RELOAD', 'false')
+AUTO_RELOAD = os.environ.get('CHAMELEON_RELOAD', 'false')
 AUTO_RELOAD = AUTO_RELOAD.lower() in TRUE
 
 for key in os.environ:


### PR DESCRIPTION
I don't see any reason to pop the values from the environment, it's an unexpected side effect when importing.
