### PR TITLE
Pass i18n_content to fill_

### DIFF
--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -1526,8 +1526,9 @@ class Compiler(object):
                             param("econtext"),
                             param("rcontext"),
                             param("__i18n_domain"),
+                            param("__i18n_context"),
                             ],
-                        defaults=[load("__i18n_domain")],
+                        defaults=[load("__i18n_domain"), load("__i18n_context")],
                         ),
                     body=body or [ast.Pass()],
                 ))


### PR DESCRIPTION
This fixes this error:

```
  File "/var/folders/p_/p3cbpfr96sb7h5gpq6vfvwcc0000gn/T/tmpRVo5yD/layout_1e6cf0c172ded7e8956ad37e5dc7fb38.py", line 434, in render
    __slot_body(__stream, econtext.copy(), rcontext)
  File "/var/folders/p_/p3cbpfr96sb7h5gpq6vfvwcc0000gn/T/tmpRVo5yD/frontpage_6f83812db3305f957715eeae137fe2a7.py", line 344, in __fill_body
    __append(translate(__msgid_4601734928, mapping={u'newline': __stream_4601418968_newline, }, default=__msgid_4601734928, domain=__i18n_domain, context=__i18n_context))
UnboundLocalError: local variable '__i18n_context' referenced before assignment
```
