### PR TITLE
Allow (but ignore) i18n:comment attributes

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1198,6 +1198,7 @@ The allowable ``i18n`` statements are:
 - ``i18n:name``
 - ``i18n:attributes``
 - ``i18n:data``
+- ``i18n:comment``
 
 ``i18n:translate``
 ^^^^^^^^^^^^^^^^^^
@@ -1321,6 +1322,19 @@ objects, one of the most obvious cases being ``datetime`` objects. The
 object.  If ``data`` is used, ``i18n:translate`` must be used to give
 an explicit message ID, rather than relying on a message ID computed
 from the content.
+
+``i18n:comment``
+^^^^^^^^^^^^^^^^
+
+The ``i18n:comment`` attribute can be used to add extra comments for
+translators. It is not used by Chameleon for processing, but will be
+picked up by tools like `lingua <pypi.python.org/pypi/lingua>`_.
+
+An example:
+
+   <h3 i18n:comment="Header for the news section"
+       i18n:translate="">News</h3>
+
 
 Relation with TAL processing
 ----------------------------

--- a/src/chameleon/i18n.py
+++ b/src/chameleon/i18n.py
@@ -30,7 +30,8 @@ WHITELIST = frozenset([
     "name",
     "mode",
     "xmlns",
-    "xml"
+    "xml",
+    "comment",
     ])
 
 _interp_regex = re.compile(r'(?<!\$)(\$(?:(%(n)s)|{(%(n)s)}))'

--- a/src/chameleon/tests/inputs/121-translation-comment.pt
+++ b/src/chameleon/tests/inputs/121-translation-comment.pt
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <h1 i18n:translate="" i18n:comment="Site title">
+      Hello world!
+    </h1>
+  </body>
+</html>

--- a/src/chameleon/tests/outputs/121.pt
+++ b/src/chameleon/tests/outputs/121.pt
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>Hello world!</h1>
+  </body>
+</html>


### PR DESCRIPTION
This adds support for a new `i18n:comment` attribute, which can be used to provide extra information to translators.
