### PR TITLE
Fix warning message

### DIFF
--- a/src/chameleon/config.py
+++ b/src/chameleon/config.py
@@ -2,6 +2,11 @@ import os
 import logging
 
 log = logging.getLogger('chameleon.config')
+environment = dict(
+    (k[10:], v) for (k, v) in (
+        ((j.lower(), x) for (j, x) in os.environ.items()))
+    if k.startswith('chameleon_')
+)
 
 # Define which values are read as true
 TRUE = ('y', 'yes', 't', 'true', 'on', '1')
@@ -9,7 +14,7 @@ TRUE = ('y', 'yes', 't', 'true', 'on', '1')
 # If eager parsing is enabled, templates are parsed upon
 # instantiation, rather than when first called upon; this mode is
 # useful for verifying validity of templates across a project
-EAGER_PARSING = os.environ.get('CHAMELEON_EAGER', 'false')
+EAGER_PARSING = environment.pop('eager', 'false')
 EAGER_PARSING = EAGER_PARSING.lower() in TRUE
 
 # Debug mode is mostly useful for debugging the template engine
@@ -18,12 +23,12 @@ EAGER_PARSING = EAGER_PARSING.lower() in TRUE
 # output. Also, the generated source code is available in the
 # ``source`` attribute of the template instance if compilation
 # succeeded.
-DEBUG_MODE = os.environ.get('CHAMELEON_DEBUG', 'false')
+DEBUG_MODE = environment.pop('debug', 'false')
 DEBUG_MODE = DEBUG_MODE.lower() in TRUE
 
 # If a cache directory is specified, template source code will be
 # persisted on disk and reloaded between sessions
-path = os.environ.get('CHAMELEON_CACHE', None)
+path = environment.pop('cache', None)
 if path is not None:
     CACHE_DIRECTORY = os.path.abspath(path)
     if not os.path.exists(CACHE_DIRECTORY):
@@ -35,13 +40,16 @@ else:
     CACHE_DIRECTORY = None
 
 # When auto-reload is enabled, templates are reloaded on file change.
-AUTO_RELOAD = os.environ.get('CHAMELEON_RELOAD', 'false')
+AUTO_RELOAD = environment.pop('reload', 'false')
 AUTO_RELOAD = AUTO_RELOAD.lower() in TRUE
 
-for key in os.environ:
-    if key.lower().startswith('chameleon'):
-        log.warn("unknown environment variable set: \"%s\"." % key)
+for key in environment:
+    log.warning(
+        "unknown environment variable set: \"CHAMELEON_%s\"." % key.upper()
+    )
 
 # This is the slice length of the expression displayed in the
 # formatted exception string
 SOURCE_EXPRESSION_MARKER_LENGTH = 60
+
+


### PR DESCRIPTION
A previous change meant that a warning was always logged (incorrectly).
Also, we fix a deprecation warning.

This closes https://github.com/malthe/chameleon/issues/186.