### PR TITLE
Allow i18n:ignore and i18n:ignore-attributes

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1199,6 +1199,8 @@ The allowable ``i18n`` statements are:
 - ``i18n:attributes``
 - ``i18n:data``
 - ``i18n:comment``
+- ``i18n:ignore``
+- ``i18n:ignore-attributes``
 
 ``i18n:translate``
 ^^^^^^^^^^^^^^^^^^
@@ -1334,6 +1336,31 @@ An example:
 
    <h3 i18n:comment="Header for the news section"
        i18n:translate="">News</h3>
+
+``i18n:ignore``
+^^^^^^^^^^^^^^^
+
+The ``i18n:ignore`` attribute can be used to inform translation extraction tools
+like `i18ndude <http://pypi.python.org/pypi/i18ndude>`_ to not give a
+warning/error on the given tag if there is no ``i18n:translate`` attribute.
+
+An example:
+
+   <h1 i18n:ignore="">News</h3>
+
+``i18n:ignore-attributes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``i18n:ignore-attributes``, just like ``i18n:ignore`` is expected to be
+used by translation extraction tools like `i18ndude <http://pypi.python.org/pypi/i18ndude>`_.
+If ``i18n:ignore`` makes text within a tag to be ignored, ``i18n:ignore-attributes``
+marks the given attributes as ignored.
+
+An example:
+
+   <a href="http://python.org"
+      title="Python!"
+      i18n:ignore-attributes="title">Python website</a>
 
 
 Relation with TAL processing

--- a/src/chameleon/i18n.py
+++ b/src/chameleon/i18n.py
@@ -32,6 +32,8 @@ WHITELIST = frozenset([
     "xmlns",
     "xml",
     "comment",
+    "ignore",
+    "ignore-attributes",
     ])
 
 _interp_regex = re.compile(r'(?<!\$)(\$(?:(%(n)s)|{(%(n)s)}))'

--- a/src/chameleon/tests/inputs/122-translation-ignore.pt
+++ b/src/chameleon/tests/inputs/122-translation-ignore.pt
@@ -1,0 +1,10 @@
+<html>
+  <body>
+    <h1 i18n:ignore="true">Hello world!</h1>
+    <a href="http://www.python.org"
+       title="Python"
+       i18n:ignore-attributes="title">
+      Python is a programming language.
+    </a>
+  </body>
+</html>

--- a/src/chameleon/tests/outputs/122.pt
+++ b/src/chameleon/tests/outputs/122.pt
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <h1>Hello world!</h1>
+    <a href="http://www.python.org"
+       title="Python">
+      Python is a programming language.
+    </a>
+  </body>
+</html>


### PR DESCRIPTION
This is used by i18ndude to mark strings and attributes on a template that should not be translatable.