### PR TITLE
Fix DeprecationWarning for inspect.getargspec() on Python 3

### DIFF
--- a/src/chameleon/codegen.py
+++ b/src/chameleon/codegen.py
@@ -91,13 +91,20 @@ def template(function, mode='exec', **kw):
         return wrapper(**kw)
 
     source = textwrap.dedent(inspect.getsource(function))
-    parameters = inspect.signature(function).parameters
-    p = [(x.name, x.default) for x in parameters.values()
-                             if x.kind in (x.POSITIONAL_ONLY,
-                                           x.POSITIONAL_OR_KEYWORD)]
-    args = [x[0] for x in p]
-    defaults = tuple(filter(lambda x: x is not inspect.Parameter.empty,
-                            [x[1] for x in p]))
+
+    try:
+        parameters = inspect.signature(function).parameters
+        p = [(x.name, x.default) for x in parameters.values()
+                                 if x.kind in (x.POSITIONAL_ONLY,
+                                               x.POSITIONAL_OR_KEYWORD)]
+        args = [x[0] for x in p]
+        defaults = tuple(filter(lambda x: x is not inspect.Parameter.empty,
+                                [x[1] for x in p]))
+    except AttributeError:
+        argspec = inspect.getargspec(function)
+        args = argspec[0]
+        defaults = argspec[3] or ()
+
     return wrapper
 
 

--- a/src/chameleon/codegen.py
+++ b/src/chameleon/codegen.py
@@ -91,9 +91,13 @@ def template(function, mode='exec', **kw):
         return wrapper(**kw)
 
     source = textwrap.dedent(inspect.getsource(function))
-    argspec = inspect.getargspec(function)
-    args = argspec[0]
-    defaults = argspec[3] or ()
+    parameters = inspect.signature(function).parameters
+    p = [(x.name, x.default) for x in parameters.values()
+                             if x.kind in (x.POSITIONAL_ONLY,
+                                           x.POSITIONAL_OR_KEYWORD)]
+    args = [x[0] for x in p]
+    defaults = tuple(filter(lambda x: x is not inspect.Parameter.empty,
+                            [x[1] for x in p]))
     return wrapper
 
 


### PR DESCRIPTION
The inspect.getargspec() function has been deprecated since Python 3.0 and will be removed in 3.6, scheduled late this year. This is a replacement using the recommended alternative approach.

All tests pass.

To keep compatibility with Python 2, it falls back to the existing code if the inspect.signature() function does not exist.