### PR TITLE
use "atexit" instead of "__del__" to remove tmp dirs

### DIFF
--- a/src/chameleon/loader.py
+++ b/src/chameleon/loader.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 import warnings
 import pkg_resources
+import atexit
 
 log = logging.getLogger('chameleon.loader')
 
@@ -105,8 +106,9 @@ class ModuleLoader(object):
     def __init__(self, path, remove=False):
         self.path = path
         self.remove = remove
+        atexit.register(self.destroy, shutil=shutil)
 
-    def __del__(self, shutil=shutil):
+    def destroy(self, shutil=shutil):
         if not self.remove:
             return
         try:


### PR DESCRIPTION
tmp dirs are not deleted when closing the web server
this is because shutils fails since it uses "isinstance" internally, but this is not available when we are in __del__ (NameError)
see for instance
https://www.toptal.com/python/top-10-mistakes-that-python-programmers-make#common-mistake-10-misusing-the-del-method

tested with python3 + apache2.4 + mod-wsgi