### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ version of Python (2.5 and up, including 3.x and `pypy
 <http://pypy.org>`_).
 
 Visit the `website <http://pagetemplates.org/>`_ for more information
-or the `documentation <http://chameleon.readthedocs.org/en/latest/>`_.
+or the `documentation <https://chameleon.readthedocs.io/en/latest/>`_.
 
 License and Copyright
 ---------------------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.