### PR TITLE
Python 3.5 AST fixes

### DIFF
--- a/src/chameleon/astutil.py
+++ b/src/chameleon/astutil.py
@@ -954,6 +954,10 @@ class NameLookupRewriteVisitor(AnnotationAwareVisitor):
         self.visit(node)
         return self.transformed
 
+    def visit_arg(self, node):
+        scope = self.scopes[-1]
+        scope.add(node.arg)
+
     def visit_Name(self, node):
         scope = self.scopes[-1]
         if isinstance(node.ctx, ast.Param):

--- a/src/chameleon/astutil.py
+++ b/src/chameleon/astutil.py
@@ -827,9 +827,13 @@ class ASTCodeGenerator(object):
                 self._write(', ')
             first = False
             # keyword = (identifier arg, expr value)
-            self._write(keyword.arg)
-            self._write('=')
+            if keyword.arg is not None:
+                self._write(keyword.arg)
+                self._write('=')
+            else:
+                self._write('**')
             self.visit(keyword.value)
+        # Attribute removed in Python 3.5
         if getattr(node, 'starargs', None):
             if not first:
                 self._write(', ')
@@ -837,6 +841,7 @@ class ASTCodeGenerator(object):
             self._write('*')
             self.visit(node.starargs)
 
+        # Attribute removed in Python 3.5
         if getattr(node, 'kwargs', None):
             if not first:
                 self._write(', ')
@@ -893,6 +898,11 @@ class ASTCodeGenerator(object):
                 raise NotImplemented('Slice type not implemented')
         _process_slice(node.slice)
         self._write(']')
+
+    # Starred(expr value, expr_context ctx)
+    def visit_Starred(self, node):
+        self._write('*')
+        self.visit(node.value)
 
     # Name(identifier id, expr_context ctx)
     def visit_Name(self, node):


### PR DESCRIPTION
This fixes *args, **kwargs, and lambda expressions in Python 3.5.

It wasn't immediately obvious where to add tests for this work, but I'll admit I also only did a cursory look at the tests module. I'll try to get back to this.

I'm also not sure if you want the comments about attrs removed in Python 3.5 as I didn't see any other similar comments.

And finally, should I open a bug report as well?