### PR TITLE
Use correct GitHub repo for homepage URL.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
       ],
     author="Malthe Borch",
     author_email="mborch@gmail.com",
-    url="https://github.com/icemac/chameleon",
+    url="https://github.com/malthe/chameleon",
     license='BSD-like (http://repoze.org/license.html)',
     packages=find_packages('src'),
     package_dir = {'': 'src'},


### PR DESCRIPTION
I'm guessing this was the original intent, especially as the @icemac forked repo no longer exists.