### PR TITLE
Fix parsing error with carriage returns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ In next release ...
 
 - Add explicit support / testing for Python 3.5.
 
+- Add ``\r`` to negative regex matches to the chameleon parser, where ``\n`` is used but ``\r`` was missing.
+  Fixes a case, where the tag name was parsed into ``html\r`` instead of ``html``.
+  Fixes: https://github.com/malthe/chameleon/issues/219
+
+
 2.24 (2015-10-28)
 -----------------
 

--- a/src/chameleon/parser.py
+++ b/src/chameleon/parser.py
@@ -11,12 +11,12 @@ from .namespaces import XML_NS
 from .tokenize import Token
 
 match_tag_prefix_and_name = re.compile(
-    r'^(?P<prefix></?)(?P<name>([^:\n ]+:)?[^ \n\t>/]+)'
+    r'^(?P<prefix></?)(?P<name>([^:\n\r ]+:)?[^ \n\t\r>/]+)'
     '(?P<suffix>(?P<space>\s*)/?>)?',
     re.UNICODE | re.DOTALL)
 match_single_attribute = re.compile(
     r'(?P<space>\s+)(?!\d)'
-    r'(?P<name>[^ =/>\n\t]+)'
+    r'(?P<name>[^ =/>\n\t\r]+)'
     r'((?P<eq>\s*=\s*)'
     r'((?P<quote>[\'"])(?P<value>.*?)(?P=quote)|'
     r'(?P<alt_value>[^\s\'">/]+))|'


### PR DESCRIPTION
Add ``\r`` to negative regex matches to the chameleon parser, where ``\n`` is used but ``\r`` was missing.
Fixes a case, where the tag name was parsed into ``html\r`` instead of ``html``.
Fixes: https://github.com/malthe/chameleon/issues/219