### PR TITLE
Fix problem with unicode attribute names

### DIFF
--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -90,7 +90,7 @@ def identifier(prefix, suffix=None):
 
 
 def mangle(string):
-    return RE_MANGLE.sub('_', str(string)).replace('\n', '').replace('-', '_')
+    return RE_MANGLE.sub('_', unicode(string)).replace('\n', '').replace('-', '_')
 
 
 def load_econtext(name):


### PR DESCRIPTION
I can`t make now a page with unicode attribute name in "tal:attributes"
