### PR TITLE
Normalize newline handling in the tests across platforms

### DIFF
--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -689,7 +689,9 @@ class ZopeTemplatesTestSuite(RenderTestCase):
                 content_type, encoding = detect_encoding(
                     output, template.default_encoding)
 
-            want = output.decode(encoding)
+            # Newline normalization across platforms
+            want = '\n'.join(output.decode(encoding).splitlines())
+            got = '\n'.join(got.splitlines())
 
             if checker.check_output(want, got, 0) is False:
                 from doctest import Example


### PR DESCRIPTION
Tests were not passing on Windows on Python 3.

Tests now pass for me on Windows 10 and Python 3.5.