### PR TITLE
Assign to macroname at the point of use, not definition.

### DIFF
--- a/src/chameleon/tests/outputs/238.pt
+++ b/src/chameleon/tests/outputs/238.pt
@@ -3,5 +3,5 @@
 
 
 
-  <h1>page</h1>
+  <h1>macros['page']</h1>
 


### PR DESCRIPTION
Refs #238 and #239.

This actually fixes running zope.app.authentication tests (using zope.app.rotterdam) under Chameleon.