### PR TITLE
Remove documentation of repeat.first/last and provide itertools.groupby example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ env25/
 env26/
 env27/
 env32/
+docs/_build/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,10 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -192,3 +195,8 @@ latex_documents = [
 
 # If false, no module index is generated.
 #latex_use_modindex = True
+
+# Configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {
+    'https://docs.python.org/': None,
+}

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,24 @@
 [tox]
-envlist = 
+envlist =
     py27,py33,py34,py35,pypy,cover
 
 [testenv]
-commands = 
+commands =
    python setup.py -q test -q
 
 [testenv:cover]
 basepython =
     python2.7
-commands = 
+commands =
     python setup.py nosetests --with-xunit --with-xcoverage
 deps =
     nose
     coverage==3.4
     nosexcover
+
+[testenv:docs]
+commands =
+    sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+deps =
+    .
+    Sphinx


### PR DESCRIPTION
Fixes #249 .

The example has to be unfortunately complex to be correct. The trivial version produces incorrect results (note the missing data in the first groups):

```pycon
In [1]: class O(object):
   ...:     def __init__(self, mt, id):
   ...:         self.meta_type = mt
   ...:         self.id = id
   ...:

In [2]: objects = [O("MT1", 1), O("MT1", 2), O("MT2", "A"), O("MT2", "B"), O("MT3", "C"), 
            O("MT4", "a")]

In [3]: from chameleon import PageTemplate

In [4]: src = """
    ...:  <div tal:repeat="type_objects itertools.groupby(objects, key=lambda o: o.meta_type)"
    ...:              tal:define="itertools import:itertools">
    ...:           <h2 tal:content="type_objects[0]">Meta Type</h2>
    ...:           <p tal:repeat="object type_objects[1]"
    ...:              tal:content="object.id">Object ID</p>
    ...:           <hr />
    ...:  </div>
    ...: """

In [5]: pt = PageTemplate(src)

In [6]: print(pt(objects=objects))

        <div>
          <h2>MT1</h2>

          <hr />
        </div>
        <div>
          <h2>MT2</h2>

          <hr />
        </div>
        <div>
          <h2>MT3</h2>

          <hr />
        </div>
        <div>
          <h2>MT4</h2>
          <p>a</p>
          <hr />
        </div>
```

It takes the complex expression in the example to get the expected
results:

```pycon
In [7]: src = """
   ...: <div tal:repeat="type_objects list(map(lambda g: (g[0], list(g[1])), itertools.groupby(objects, key=lambda o: o.meta_type)))"
   ...:              tal:define="itertools import:itertools">
   ...:           <h2 tal:content="type_objects[0]">Meta Type</h2>
   ...:           <p tal:repeat="object type_objects[1]"
   ...:              tal:content="object.id">Object ID</p>
   ...:           <hr />
   ...:  </div>
   ...: """

In [8]: pt = PageTemplate(src)

In [9]: print(pt(objects=objects))

        <div>
          <h2>MT1</h2>
          <p>1</p>
          <p>2</p>
          <hr />
        </div>
        <div>
          <h2>MT2</h2>
          <p>A</p>
          <p>B</p>
          <hr />
        </div>
        <div>
          <h2>MT3</h2>
          <p>C</p>
          <hr />
        </div>
        <div>
          <h2>MT4</h2>
          <p>a</p>
          <hr />
        </div>
```

- Introduce a tox ``docs`` environment for ease of building the docs.
- Add intersphinx references to docs.python.org for linking to
  itertools.groupby.