### PR TITLE
Fix edge case in exception handler causing recursion

### DIFF
--- a/src/chameleon/exc.py
+++ b/src/chameleon/exc.py
@@ -2,6 +2,7 @@
 
 import traceback
 
+from .utils import create_formatted_exception
 from .utils import format_kwargs
 from .utils import safe_native
 from .tokenize import Token
@@ -317,6 +318,11 @@ class ExceptionFormatter(object):
 
         out.append(" - Arguments:  %s" % "\n".join(formatted))
 
+        if isinstance(exc.__str__, ExceptionFormatter):
+            # This is a nested error that has already been wrapped
+            # We must unwrap it before trying to format it to prevent
+            # recursion
+            exc = create_formatted_exception(exc, type(exc), exc._original__str__)
         formatted = traceback.format_exception_only(type(exc), exc)[-1]
         formatted_class = "%s:" % type(exc).__name__
 

--- a/src/chameleon/utils.py
+++ b/src/chameleon/utils.py
@@ -214,6 +214,7 @@ def create_formatted_exception(exc, cls, formatter, base=Exception):
         try:
             new = type(cls.__name__, (cls, base), {
                 '__str__': formatter,
+                '_original__str__': exc.__str__,
                 '__new__': BaseException.__new__,
                 '__module__': cls.__module__,
                 })


### PR DESCRIPTION
During Plone's porting efforts to Python 3.6 a bug was found
that caused Python to dump core with a stack overflow. This
is caused in the field handling, where a template calls a
macro which then inserts the rendered body of another pagetemplate.

The inner page template is rendered and calls the exception handler
correctly, which causes the exception's `__str__` method to be
replaced with an instance of `ExceptionFormatter`. However, as
this is within a macro the `visit_Macro` function causes that
exception to be added to `rcontext['__error__']`, meaning that
when the outer template attempts to format its exception the
handling of the `__errors__` list causes recursion into the
`ExceptionFormatter` until the maximum recursion depth is reached
at which point the error handling is aborted as unformattable
by the traceback module in the standard library.

If the exception is sufficiently large it smashes the stack before
this can happen, causing a core dump. If it isn't sufficiently
large a confusingly repetitious error is shown.