### PR TITLE
Add token fix to reset errors before rendering internal macros

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changes
 
 Bugfixes:
 
+- Reset error token when rendering internal macro calls.
+
 - Fix edge case in exception handler causing recursion.
   [MatthewWilkes]
 

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -1493,8 +1493,8 @@ class Compiler(object):
             render = "render"
         else:
             render = "render_%s" % mangle(node.name)
-
-        return template(
+        token_reset = template("__token = None")
+        return token_reset + template(
             "f(__stream, econtext.copy(), rcontext, __i18n_domain)",
             f=render) + \
             template("econtext.update(rcontext)")


### PR DESCRIPTION
This was discussed in issue #260.