### PR TITLE
Fix missing python interpreters on TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,15 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
-  - 3.8
+  - pypy3
+matrix:
+    include:
+        - python: "3.7"
+          dist: xenial
+          sudo: true
+        - python: "3.8-dev"
+          dist: xenial
+          sudo: true
 
 install:
   - python setup.py install


### PR DESCRIPTION
Python 3.7+ is only available on `xenial`.
Added PyPy3 to the text matrix.

The test failure on Python 3.8 seems to be an actual error.