### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - 2.7
   - pypy
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Chameleon is an HTML/XML template engine for `Python
 <http://www.python.org>`_. It uses the *page templates* language.
 
 You can use it in any Python web application with just about any
-version of Python (2.7 and up, including 3.3+ and `pypy
+version of Python (2.7 and up, including 3.4+ and `pypy
 <http://pypy.org>`_).
 
 Visit the `documentation <https://chameleon.readthedocs.io/en/latest/>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ typically HTML markup or XML.
 The language used is *page templates*, originally a `Zope
 <http://www.zope.org>`_ invention [1]_, but available here as a
 :ref:`standalone library <no-dependencies>` that you can use in any
-script or application running Python 2.5 and up (including 3.x and
+script or application running Python 2.7 and up, including 3.4+ and
 `pypy <http://pypy.org>`_). It comes with a set of :ref:`new features
 <new-features>`, too.
 


### PR DESCRIPTION
As it is eol since September 29, 2017, cf
https://www.python.org/dev/peps/pep-0398/#x-end-of-life

modified:   .travis.yml
modified:   README.rst
modified:   docs/index.rst