### PR TITLE
Handle recursion limit as a special case

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Changes
 
 In next release ...
 
+- Exclude `RuntimeError` (or `RecursionError` when available) from
+  exception wrapping.
+
 - Drop support for Python 3.3.
 
 3.5 (2018-10-17)

--- a/src/chameleon/template.py
+++ b/src/chameleon/template.py
@@ -7,6 +7,10 @@ import logging
 import tempfile
 import inspect
 
+try:
+    RecursionError
+except NameError:
+    RecursionError = RuntimeError
 
 def get_package_versions():
     try:
@@ -181,6 +185,8 @@ class BaseTemplate(object):
         stream = self.output_stream_factory()
         try:
             self._render(stream, econtext, rcontext)
+        except RecursionError:
+            raise
         except:
             cls, exc, tb = sys.exc_info()
             errors = rcontext.get('__error__')

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -16,6 +16,10 @@ try:
 except ImportError:
     from unittest import TestCase
 
+try:
+    RecursionError
+except NameError:
+    RecursionError = RuntimeError
 
 from chameleon.utils import byte_string
 from chameleon.exc import RenderError
@@ -301,6 +305,16 @@ class ZopePageTemplatesTest(RenderTestCase):
             body = f.read()
 
         self.from_string(body)
+
+    def test_recursion_error(self):
+        template = self.from_string(
+            '<div metal:define-macro="main" '
+            'metal:use-macro="template.macros.main" />'
+        )
+        self.assertRaises(
+            RecursionError,
+            template
+        )
 
     def test_unicode_decode_error(self):
         template = self.from_file(

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -311,10 +311,11 @@ class ZopePageTemplatesTest(RenderTestCase):
             '<div metal:define-macro="main" '
             'metal:use-macro="template.macros.main" />'
         )
-        self.assertRaises(
-            RecursionError,
-            template
-        )
+        self.assertRaises(RecursionError, template)
+        try:
+            template()
+        except RecursionError as exc:
+            self.assertFalse(isinstance(exc, RenderError))
 
     def test_unicode_decode_error(self):
         template = self.from_file(


### PR DESCRIPTION
This change attempts to address a situation where the exception wrapping might cause an overflow situation.