### PR TITLE
Fix SyntaxWarnings in Python 3.8 when comparing literals with is

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 3.7 (unreleased)
 ----------------
 
-...
+- Fix SyntaxWarnings in Python 3.8 resulting from comparing literals with 'is'.
+  See https://github.com/plone/Products.CMFPlone/issues/2890.
 
 3.6.1 (2019-04-01)
 ------------------

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -147,7 +147,7 @@ emit_node_if_non_trivial = template(is_func=True, func_args=('node',),
 emit_bool = template(is_func=True,
                      func_args=('target', 's', 'default_marker', 'default'),
                      func_defaults=(None, None), source=r"""
-    if target is default_marker:
+    if target == default_marker:
         target = default
     elif target:
         target = s
@@ -163,7 +163,7 @@ emit_convert = template(is_func=True,
                         source=r"""
     if target is None:
         pass
-    elif target is default_marker:
+    elif target == default_marker:
         target = default
     else:
         __tt = type(target)
@@ -216,8 +216,8 @@ emit_translate = template(is_func=True,
                           'default'),
                           func_defaults=(None,),
                           source=r"""
-    target = translate(msgid, default=default, domain=__i18n_domain, 
-                       context=__i18n_context, 
+    target = translate(msgid, default=default, domain=__i18n_domain,
+                       context=__i18n_context,
                        target_language=target_language)""")
 
 
@@ -230,7 +230,7 @@ emit_func_convert_and_escape = template(
         if target is None:
             return
 
-        if target is default_marker:
+        if target == default_marker:
             return default
 
         __tt = type(target)

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -147,7 +147,7 @@ emit_node_if_non_trivial = template(is_func=True, func_args=('node',),
 emit_bool = template(is_func=True,
                      func_args=('target', 's', 'default_marker', 'default'),
                      func_defaults=(None, None), source=r"""
-    if target == default_marker:
+    if target is default_marker:
         target = default
     elif target:
         target = s
@@ -163,7 +163,7 @@ emit_convert = template(is_func=True,
                         source=r"""
     if target is None:
         pass
-    elif target == default_marker:
+    elif target is default_marker:
         target = default
     else:
         __tt = type(target)
@@ -230,7 +230,7 @@ emit_func_convert_and_escape = template(
         if target is None:
             return
 
-        if target == default_marker:
+        if target is default_marker:
             return default
 
         __tt = type(target)
@@ -949,7 +949,7 @@ class Compiler(object):
             module = ast.Module([])
             module.body += self.visit(node)
             ast.fix_missing_locations(module)
-            prelude = "__filename = %r" % filename
+            prelude = "__filename = %r\n__default = object()" % filename
             generator = TemplateCodeGenerator(module, source)
             tokens = [
                 Token(source[pos:pos + length], pos, source)

--- a/src/chameleon/zpt/template.py
+++ b/src/chameleon/zpt/template.py
@@ -209,7 +209,7 @@ class PageTemplate(BaseTemplate):
     @property
     def engine(self):
         if self.literal_false:
-            default_marker = ast.Str(s="__default__")
+            default_marker = Builtin("__default")
         else:
             default_marker = Builtin("False")
 
@@ -225,7 +225,7 @@ class PageTemplate(BaseTemplate):
 
     def parse(self, body):
         if self.literal_false:
-            default_marker = ast.Str(s="__default__")
+            default_marker = Builtin("__default")
         else:
             default_marker = Builtin("False")
 


### PR DESCRIPTION
Instead you should use `==`
See https://github.com/plone/Products.CMFPlone/issues/2890 for the original bug-report.

See https://bugs.python.org/issue34850 for the change in Python.