### PR TITLE
Fix compatibility with Python 3.9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+In next release ...
+
+- Fix compatiblity issue with Python 3.9.
+
+
 3.7.0 (2020-03-26)
 ------------------
 

--- a/src/chameleon/astutil.py
+++ b/src/chameleon/astutil.py
@@ -123,7 +123,8 @@ def copy(source, target):
     target.__dict__ = source.__dict__
 
 
-def swap(root, replacement, name):
+def swap(body, replacement, name):
+    root = ast.Expression(body=body)
     for node in ast.walk(root):
         if (isinstance(node, ast.Name) and
             isinstance(node.ctx, ast.Load) and

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -1306,8 +1306,8 @@ class Compiler(object):
 
         # Visit body to generate the message body
         code = self.visit(node.node)
-        swap(ast.Suite(body=code), load(append), "__append")
-        swap(ast.Suite(body=code), load(stream), "__stream")
+        swap(code, load(append), "__append")
+        swap(code, load(stream), "__stream")
         body += code
 
         # Reduce white space and assign as message id
@@ -1545,7 +1545,7 @@ class Compiler(object):
 
         # generate code
         code = self.visit(node.node)
-        swap(ast.Suite(body=code), load(append), "__append")
+        swap(code, load(append), "__append")
         body += code
 
         # output msgid


### PR DESCRIPTION
The `ast.Suite` node type is no longer supported by the `ast.walk` function (having been marked as deprecated and will be removed from the parser) which caused problems for the compiler. Swapping the node out with `ast.Expression` fixes the issue.