### PR TITLE
Default should be a global object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Changes
 
 In next release ...
 
+- Fix regression introduced in 3.6.2 where the default marker would
+  incorrectly change its value between templates, causing issues in
+  software which depends on the value being treated as a global
+  object.
+
 3.7.2 (2020-05-31)
 ------------------
 

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -949,7 +949,6 @@ class Compiler(object):
             module = ast.Module([])
             module.body += self.visit(node)
             ast.fix_missing_locations(module)
-            prelude = "__filename = %r\n__default = object()" % filename
             generator = TemplateCodeGenerator(module, source)
             tokens = [
                 Token(source[pos:pos + length], pos, source)
@@ -966,7 +965,8 @@ class Compiler(object):
                 self.lock.release()
 
         self.code = "\n".join((
-            prelude,
+            "__filename = %r\n"
+            "__default = intern('__default__')" % filename,
             token_map_def,
             generator.code
         ))


### PR DESCRIPTION
Note that we use 'intern' here to assert that the string will indeed be interned (and become a global), but also to prevent Python from complaining that we're abusing object identity with strings (which is discouraged in Python 3.8).

This problem may be solved differently in a future release.