### PR TITLE
fix chameleon `default` handling

### DIFF
--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -564,6 +564,8 @@ class ExpressionEngine(object):
         entity = char2entity(quote or '\0')
 
         return template(
+            ("" if getattr(self, "literal_false", True)
+            else "if TARGET is False: TARGET = None\n") +
             "TARGET = __quote(TARGET, QUOTE, Q_ENTITY, DEFAULT, MARKER)",
             TARGET=target,
             QUOTE=ast.Str(s=quote),
@@ -818,6 +820,7 @@ class ExpressionTransform(object):
 
     def visit_Substitution(self, node, target):
         engine = self.engine_factory(default=node.default)
+        engine.literal_false = node.literal_false
         compiler = engine.parse(node.value, char_escape=node.char_escape)
         return compiler.assign_text(target)
 
@@ -862,6 +865,7 @@ class ExpressionTransform(object):
             decode_htmlentities=True
         )
 
+        engine.literal_false = node.literal_false
         compiler = engine.get_compiler(
             interpolator, expr.value, True, ()
         )

--- a/src/chameleon/nodes.py
+++ b/src/chameleon/nodes.py
@@ -51,9 +51,10 @@ class Value(Node):
 class Substitution(Value):
     """Expression value for text substitution."""
 
-    _fields = "value", "char_escape", "default"
+    _fields = "value", "char_escape", "default", "literal_false"
 
     default = None
+    literal_false = True
 
 
 class Boolean(Value):
@@ -184,7 +185,9 @@ class Text(Node):
 class Interpolation(Node):
     """String interpolation output."""
 
-    _fields = "value", "braces_required", "translation"
+    _fields = "value", "braces_required", "translation", "literal_false"
+
+    literal_false = True
 
 
 class Translate(Node):

--- a/src/chameleon/tests/inputs/022-switch.pt
+++ b/src/chameleon/tests/inputs/022-switch.pt
@@ -6,7 +6,7 @@
       <span tal:case="True">ok</span>
       <span tal:case="default">bad</span>
       <span tal:case="True">bad</span>
-      ${default|string:ok}
+      ${undefined|string:ok}
     </div>
     <div tal:switch="True">
       <span tal:case="False">bad</span>

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -322,7 +322,7 @@ class ZopePageTemplatesTest(RenderTestCase):
             os.path.join(self.root, 'inputs', 'greeting.pt')
             )
 
-        string = native = "the artist formerly known as ƤŗíƞĆě"
+        string = native = "the artist formerly known as ?ŗí?Ćě"
         try:
             string = string.decode('utf-8')
         except AttributeError:
@@ -759,6 +759,7 @@ class ZopeTemplatesTestSuite(RenderTestCase):
             params.update({
                 'translate': translate,
                 'target_language': language,
+                'default': intern('__default__'),
                 })
 
             template.cook_check()

--- a/src/chameleon/zpt/program.py
+++ b/src/chameleon/zpt/program.py
@@ -749,7 +749,7 @@ class MacroProgram(ElementProgram):
 
         if default is not None:
             content = nodes.Condition(
-                nodes.Identity(value, marker("default")),
+                nodes.Identity(value, self.default_marker),
                 default,
                 content,
                 )
@@ -757,11 +757,6 @@ class MacroProgram(ElementProgram):
             # Cache expression to avoid duplicate evaluation
             content = nodes.Cache([value], content)
 
-            # Define local marker "default"
-            content = nodes.Define(
-                [nodes.Alias(["default"], marker("default"))],
-                content
-                )
 
         return content
 

--- a/src/chameleon/zpt/program.py
+++ b/src/chameleon/zpt/program.py
@@ -112,6 +112,12 @@ class MacroProgram(ElementProgram):
     # means that the attribute is dropped.
     default_marker = None
 
+    # If ``literal_false`` has a false value, then an attribute value
+    # ``False`` is treated like ``None``, i.e. the attribute is dropped
+    # If ``literal_false`` has a true value, ``False`` is not treated
+    # specially.
+    literal_false = False
+
     # Escape mode (true value means XML-escape)
     escape = True
 
@@ -161,6 +167,7 @@ class MacroProgram(ElementProgram):
             kwargs,
             'boolean_attributes',
             'default_marker',
+            'literal_false',
             'escape',
             'implicit_i18n_translate',
             'implicit_i18n_attributes',
@@ -790,7 +797,8 @@ class MacroProgram(ElementProgram):
             if expr is None and text is not None and '${' in text:
                 expr = nodes.Substitution(text, char_escape)
                 translation = implicit_i18n and msgid is missing
-                value = nodes.Interpolation(expr, True, translation)
+                value = nodes.Interpolation(
+                    expr, True, translation, literal_false=self.literal_false)
                 default_marker = self.default_marker
 
             # If the expression is non-trivial, the attribute is
@@ -816,7 +824,8 @@ class MacroProgram(ElementProgram):
                     value = nodes.Substitution(
                         decode_htmlentities(expr),
                         char_escape,
-                        default
+                        default,
+                        self.literal_false
                     )
 
             # Otherwise, it's a static attribute. We don't include it

--- a/src/chameleon/zpt/template.py
+++ b/src/chameleon/zpt/template.py
@@ -217,10 +217,7 @@ class PageTemplate(BaseTemplate):
 
     @property
     def engine(self):
-        if self.literal_false:
-            default_marker = Builtin("__default")
-        else:
-            default_marker = Builtin("False")
+        default_marker = Builtin("__default")
 
         return partial(
             ExpressionEngine,
@@ -233,15 +230,13 @@ class PageTemplate(BaseTemplate):
         return ExpressionParser(self.expression_types, self.default_expression)
 
     def parse(self, body):
-        if self.literal_false:
-            default_marker = Builtin("__default")
-        else:
-            default_marker = Builtin("False")
+        default_marker = Builtin("__default")
 
         return MacroProgram(
             body, self.mode, self.filename,
             escape=True if self.mode == "xml" else False,
             default_marker=default_marker,
+            literal_false=self.literal_false,
             boolean_attributes=self.boolean_attributes,
             implicit_i18n_translate=self.implicit_i18n_translate,
             implicit_i18n_attributes=self.implicit_i18n_attributes,


### PR DESCRIPTION
Use the `default_marker` integration parameter rather than a locally defined `marker("default")` as representation of the TALES default object.

This fix would resolve "https://github.com/zopefoundation/Zope/pull/853".