### PR TITLE
Fix default handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,11 @@ Changes
 
 In next release ...
 
--
+- Expose default marker as importable symbol
+  `chameleon.tales.DEFAULT_MARKER`.
+
+- Removed legacy flag `literal_false`. To get a similar behavior, use
+  `boolean_attributes`.
 
 3.7.4 (2020-06-17)
 ------------------

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -882,6 +882,10 @@ class ExpressionTransform(object):
         value = annotated(node)
         return [ast.Assign(targets=[target], value=value)]
 
+    def visit_Symbol(self, node, target):
+        value = annotated(node)
+        return template("TARGET = SYMBOL", TARGET=target, SYMBOL=node)
+
 
 class Compiler(object):
     """Generic compiler class.

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -812,10 +812,6 @@ class ExpressionTransform(object):
     def visit_Copy(self, node, target):
         return self.translate(node.expression, target)
 
-    def visit_Default(self, node, target):
-        value = annotated(node.marker)
-        return [ast.Assign(targets=[target], value=value)]
-
     def visit_Substitution(self, node, target):
         engine = self.engine_factory(default=node.default)
         compiler = engine.parse(node.value, char_escape=node.char_escape)

--- a/src/chameleon/nodes.py
+++ b/src/chameleon/nodes.py
@@ -22,12 +22,6 @@ class Content(Node):
     _fields = "expression", "char_escape", "translate"
 
 
-class Default(Node):
-    """Represents a default value."""
-
-    _fields = "marker",
-
-
 class CodeBlock(Node):
     _fields = "source",
 

--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import types
+import importlib
 
 from .astutil import parse
 from .astutil import store
@@ -21,7 +22,7 @@ from .compiler import Interpolator
 
 # We're using a module as the default marker value by virtue of it being
 # importable and not callable.
-from . import tales as DEFAULT_MARKER
+DEFAULT_MARKER = importlib.import_module(__name__)
 
 try:
     from .py26 import lookup_attr

--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -24,6 +24,13 @@ except SyntaxError:
     from .py25 import lookup_attr
 
 
+class DEFAULT_MARKER(object):
+    """Represents a default marker.
+
+    This must be an importable symbol.
+    """
+
+
 split_parts = re.compile(r'(?<!\\)\|')
 match_prefix = re.compile(r'^\s*([a-z][a-z0-9\-_]*):').match
 re_continuation = re.compile(r'\\\s*$', re.MULTILINE)

--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -1,5 +1,6 @@
 import re
 import sys
+import types
 
 from .astutil import parse
 from .astutil import store
@@ -24,12 +25,7 @@ except SyntaxError:
     from .py25 import lookup_attr
 
 
-class DEFAULT_MARKER(object):
-    """Represents a default marker.
-
-    This must be an importable symbol.
-    """
-
+DEFAULT_MARKER = types.ModuleType(__name__)
 
 split_parts = re.compile(r'(?<!\\)\|')
 match_prefix = re.compile(r'^\s*([a-z][a-z0-9\-_]*):').match

--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -19,13 +19,15 @@ from .tokenize import Token
 from .parser import substitute
 from .compiler import Interpolator
 
+# We're using a module as the default marker value by virtue of it being
+# importable and not callable.
+from . import tales as DEFAULT_MARKER
+
 try:
     from .py26 import lookup_attr
 except SyntaxError:
     from .py25 import lookup_attr
 
-
-DEFAULT_MARKER = types.ModuleType(__name__)
 
 split_parts = re.compile(r'(?<!\\)\|')
 match_prefix = re.compile(r'^\s*([a-z][a-z0-9\-_]*):').match

--- a/src/chameleon/tests/inputs/005-default.pt
+++ b/src/chameleon/tests/inputs/005-default.pt
@@ -2,7 +2,7 @@
   <body>
     <img class="default" tal:attributes="class default" />
     <img tal:attributes="class default" />
-    <span tal:content="default">Default</span>
+    <span tal:define="foo string:" tal:content="foo or default">Default</span>
     <span tal:content="True">Default</span>
     <span tal:content="False">Default</span>
     <span tal:content="default">

--- a/src/chameleon/tests/inputs/072-repeat-interpolation.pt
+++ b/src/chameleon/tests/inputs/072-repeat-interpolation.pt
@@ -6,8 +6,5 @@
     <ul>
       <li tal:repeat="i range(1, 4)" class="${'odd' if i % 2 != 0 else None}">${i}</li>
     </ul>
-    <ul>
-      <li tal:repeat="i range(1, 4)" class="${'odd' if i % 2 != 0 else False}">${i}</li>
-    </ul>
   </body>
 </html>

--- a/src/chameleon/tests/outputs/028.pt
+++ b/src/chameleon/tests/outputs/028.pt
@@ -1,5 +1,5 @@
 <div xmlns="http://www.w3.org/1999/xhtml">
   <option selected="True"></option>
-  <option></option>
+  <option selected="False"></option>
   <option></option>
 </div>

--- a/src/chameleon/tests/outputs/071.pt
+++ b/src/chameleon/tests/outputs/071.pt
@@ -1,7 +1,7 @@
 <html>
   <body>
     <input type="input" checked="True" />
-    <input type="input" />
+    <input type="input" checked="False" />
     <input type="input" />
     <input type="input" checked="checked" />
     <input type="input" checked />

--- a/src/chameleon/tests/outputs/072.pt
+++ b/src/chameleon/tests/outputs/072.pt
@@ -10,10 +10,5 @@
       <li>2</li>
       <li class="odd">3</li>
     </ul>
-    <ul>
-      <li class="odd">1</li>
-      <li>2</li>
-      <li class="odd">3</li>
-    </ul>
   </body>
 </html>

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -23,6 +23,7 @@ except NameError:
 
 from chameleon.utils import byte_string
 from chameleon.exc import RenderError
+from chameleon.tales import DEFAULT_MARKER
 
 
 class Message(object):
@@ -572,6 +573,14 @@ class ZopePageTemplatesTest(RenderTestCase):
         result = template(macro=macro)
         self.assertTrue('foo' in result)
         self.assertTrue('foo' in result)
+
+    def test_default_marker(self):
+        template = self.from_string('<span tal:replace="id(default)" />')
+        self.assertEqual(
+            template(),
+            str(id(DEFAULT_MARKER)),
+            template.source
+        )
 
     def test_boolean_attributes(self):
         template = self.from_string(

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -573,24 +573,6 @@ class ZopePageTemplatesTest(RenderTestCase):
         self.assertTrue('foo' in result)
         self.assertTrue('foo' in result)
 
-    def test_literal_false(self):
-        template = self.from_string(
-            '<input type="input" tal:attributes="checked False" />'
-            '<input type="input" tal:attributes="checked True" />'
-            '<input type="input" tal:attributes="checked None" />'
-            '<input type="input" tal:attributes="checked default" />',
-            literal_false=True,
-            )
-
-        self.assertEqual(
-            template(),
-            '<input type="input" checked="False" />'
-            '<input type="input" checked="True" />'
-            '<input type="input" />'
-            '<input type="input" />',
-            template.source
-            )
-
     def test_boolean_attributes(self):
         template = self.from_string(
             '<input type="input" tal:attributes="checked False" />'

--- a/src/chameleon/zpt/program.py
+++ b/src/chameleon/zpt/program.py
@@ -749,7 +749,7 @@ class MacroProgram(ElementProgram):
 
         if default is not None:
             content = nodes.Condition(
-                nodes.Identity(value, marker("default")),
+                nodes.Identity(value, self.default_marker),
                 default,
                 content,
                 )
@@ -759,7 +759,7 @@ class MacroProgram(ElementProgram):
 
             # Define local marker "default"
             content = nodes.Define(
-                [nodes.Alias(["default"], marker("default"))],
+                [nodes.Alias(["default"], self.default_marker)],
                 content
                 )
 


### PR DESCRIPTION
Default marker is now an importable symbol `chameleon.tales.DEFAULT_MARKER`.
    
This is useful for integrations which might need to return a value of _default_ rather than a computed value.
