### PR TITLE
Fix a deprecation warning

### DIFF
--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -396,7 +396,7 @@ class StringExpr(object):
     In previous versions, it was possible to escape using a regular
     backslash coding, but this is no longer supported.
 
-    >>> test(StringExpr(r'\${name}'), name='Hello world!')
+    >>> test(StringExpr(r'\\${name}'), name='Hello world!')
     '\\\\Hello world!'
 
     Multiple interpolations in one:


### PR DESCRIPTION
Fix a warning about escapes:
```
chameleon/tales.py:464: DeprecationWarning: invalid escape sequence \$
```