### PR TITLE
Packaging maintenance and updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,16 @@
 .coverage
 .tox/
 coverage.xml
+default.profraw
 nosetests.xml
+pyvenv.cfg
 *.tar.gz
+.eggs/
+bin/
 env25/
 env26/
 env27/
 env32/
 docs/_build/
+htmlcov/
+lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,32 @@
 language: python
 
-python:
-  - 2.7
-  - pypy
-  - 3.4
-  - 3.5
-  - 3.6
-  - pypy3
 matrix:
     include:
+        - python: "2.7"
+          env: TOXENV=py27
+        - python: "pypy"
+          env: TOXENV=pypy
+        - python: "3.5"
+          env: TOXENV=py35
+        - python: "3.6"
+          env: TOXENV=py36
         - python: "3.7"
-          dist: xenial
-          sudo: true
-        - python: "3.8-dev"
-          dist: xenial
-          sudo: true
+          env: TOXENV=py37
+        - python: "pypy3"
+          env: TOXENV=pypy3
+        - python: "3.8"
+          env: TOXENV=py38
+        - python: "3.9"
+          env: TOXENV=py39
 
 install:
-  - python setup.py install
+  - pip install -U pip
+  - pip install -U tox coverage
 
 script:
-  - python setup.py -q test -q
+  - tox
+
+cache:
+  pip: true
+  directories:
+    - eggs/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changes
 
 In next release ...
 
--
+- Dropped support for obsolete Python 3.4
 
 3.8.1 (2020-07-06)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[bdist_wheel]
+universal = 1
+
+[coverage:run]
+branch = True
+source = src
+omit =
+    */tests/*
+
+[coverage:report]
+precision = 2
+show_missing = False
+sort = Name

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-__version__ = '3.8.2-dev'
+__version__ = '3.8.2.dev0'
 
 import os
 
@@ -46,7 +46,6 @@ setup(
        "Programming Language :: Python :: 2",
        "Programming Language :: Python :: 3",
        "Programming Language :: Python :: 2.7",
-       "Programming Language :: Python :: 3.4",
        "Programming Language :: Python :: 3.5",
        "Programming Language :: Python :: 3.6",
        "Programming Language :: Python :: 3.7",
@@ -58,15 +57,19 @@ setup(
     author="Malthe Borch",
     author_email="mborch@gmail.com",
     url="https://chameleon.readthedocs.io",
+    project_urls={
+       'Documentation': 'https://chameleon.readthedocs.io',
+       'Issue Tracker': 'https://github.com/malthe/chameleon/issues',
+       'Sources': 'https://github.com/malthe/chameleon',
+    },
     license='BSD-like (http://repoze.org/license.html)',
     packages=find_packages('src'),
     package_dir = {'': 'src'},
     include_package_data=True,
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     install_requires=install_requires,
     zip_safe=False,
-    test_suite="chameleon.tests",
     cmdclass={
         'benchmark': Benchmark,
         }
     )
-

--- a/src/chameleon/tests/test_astutil.py
+++ b/src/chameleon/tests/test_astutil.py
@@ -10,22 +10,23 @@ class ASTCodeGeneratorTestCase(unittest.TestCase):
         code = compile(source, '<string>', 'exec')
         exec(code, env)
 
-    if sys.version_info >= (3, 7):
-        def test_slice(self):
-            tree = ast.Module(
-                body=[
-                    ast.Assign(
-                        targets=[
-                            ast.Name(id='x', ctx=ast.Store())],
-                        value=ast.Call(
-                            func=ast.Name(id='f', ctx=ast.Load()),
-                            args=[
-                                ast.Slice(
-                                    upper=ast.Constant(value=0))],
-                            keywords=[]))],
-                type_ignores=[]
-            )
-            def f(x): return x
-            d = {"f": f}
-            self._eval(tree, d)
-            assert d['x'] == slice(None, 0, None)
+    @unittest.skipIf(sys.version_info < (3, 7),
+                     'Only applicable on Python 3.7+')
+    def test_slice(self):
+        tree = ast.Module(
+            body=[
+                ast.Assign(
+                    targets=[
+                        ast.Name(id='x', ctx=ast.Store())],
+                    value=ast.Call(
+                        func=ast.Name(id='f', ctx=ast.Load()),
+                        args=[
+                            ast.Slice(
+                                upper=ast.Constant(value=0))],
+                        keywords=[]))],
+            type_ignores=[]
+        )
+        def f(x): return x
+        d = {"f": f}
+        self._eval(tree, d)
+        assert d['x'] == slice(None, 0, None)

--- a/src/chameleon/tests/test_loader.py
+++ b/src/chameleon/tests/test_loader.py
@@ -103,8 +103,3 @@ class ZPTLoadTests(unittest.TestCase):
         template = loader["hello_world.pt"]
         from chameleon.zpt.template import PageTemplateFile
         self.assertTrue(isinstance(template, PageTemplateFile))
-
-
-def test_suite():
-    import sys
-    return unittest.findTestCases(sys.modules[__name__])

--- a/src/chameleon/tests/test_sniffing.py
+++ b/src/chameleon/tests/test_sniffing.py
@@ -115,10 +115,3 @@ class TypeSniffingTestCase(unittest.TestCase):
 
         template = self.get_template(body)
         self.assertEqual(template.body, body.decode('windows-1251'))
-
-
-def test_suite():
-    return unittest.makeSuite(TypeSniffingTestCase)
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="test_suite")

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,24 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,py37,pypy,pypy3,cover
+    py27,py35,py36,py37,py38,py39,pypy,pypy3,cover
 
 [testenv]
 commands =
-   python setup.py -q test -q
+   {envdir}/bin/zope-testrunner --path {toxinidir}/src {posargs:-vc}
+deps =
+    zope.testrunner
+    chameleon
 
 [testenv:cover]
 basepython =
-    python2.7
+    python3
 commands =
-    python setup.py nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner -m chameleon --path={toxinidir}/src []
+    coverage html -i
+    coverage report -i
 deps =
-    nose
-    coverage==3.4
-    nosexcover
+    {[testenv]deps}
+    coverage
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
This PR updates package management-related configurations:

- normalize the development version number to prevent deprecation warnings
- add setuptools data for documentation links and the required Python versions
- drop support for the obsolete Python 3.4
- use a test runner instead of relying on the deprecated setuptools test facility
- make sure tox tests all supported Python versions
- update the Travis CI configuration to run the tests through tox

Let me know what you think.