### PR TITLE
Fixed namespace handling when redefining a variable in the same define

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ In next release ...
 
 - Dropped support for obsolete Python 3.4
 
+- Fixed namespace handling when redefining a variable in the same ``tal:define``
+  (`#237 <https://github.com/malthe/chameleon/issues/237>`_)
+
 3.8.1 (2020-07-06)
 ------------------
 

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -1313,7 +1313,7 @@ class Compiler(object):
         for stmt in self.visit(node.node):
             yield stmt
 
-        for assignment in node.assignments:
+        for assignment in reversed(node.assignments):
             if assignment.local:
                 for stmt in self._leave_assignment(assignment.names):
                     yield stmt

--- a/src/chameleon/tests/inputs/237-double-define.pt
+++ b/src/chameleon/tests/inputs/237-double-define.pt
@@ -1,5 +1,5 @@
 <p tal:define="local_value python: 35;
-               local_value python: 33">
+               local_value python: local_value - 2">
   ${local_value}
 </p>
 <p tal:content="local_value|default">OUTSIDE: No value</p>

--- a/src/chameleon/tests/inputs/237-double-define.pt
+++ b/src/chameleon/tests/inputs/237-double-define.pt
@@ -1,0 +1,5 @@
+<p tal:define="local_value python: 35;
+               local_value python: 33">
+  ${local_value}
+</p>
+<p tal:content="local_value|default">OUTSIDE: No value</p>

--- a/src/chameleon/tests/outputs/237.pt
+++ b/src/chameleon/tests/outputs/237.pt
@@ -1,0 +1,4 @@
+<p>
+  33
+</p>
+<p>OUTSIDE: No value</p>


### PR DESCRIPTION
Fixes #237 

This PR attempts to fix the incorrect handling of local variable scope cleanup by simply "un-winding" assignments in reverse order. That way the backup values for each assignment are restored in correct order.