### PR TITLE
Do not silently ignore unclosed tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ In next release ...
 
 - Dropped support for obsolete Python 3.4
 
+- Do not silently ignore unclosed tags
+  (`#327 <https://github.com/malthe/chameleon/issues/327>`_)
+
 3.8.1 (2020-07-06)
 ------------------
 

--- a/src/chameleon/parser.py
+++ b/src/chameleon/parser.py
@@ -10,6 +10,14 @@ from .exc import ParseError
 from .namespaces import XML_NS
 from .tokenize import Token
 
+
+# List of HTML tags with an empty content model; these are
+# rendered in minimized form, e.g. ``<img />``.
+# From http://www.w3.org/TR/xhtml1/#dtds
+EMPTY_HTML_TAGS = frozenset([
+    "base", "meta", "link", "hr", "br", "param", "img", "area",
+    "input", "col", "basefont", "isindex", "frame",
+    ])
 match_double_hyphen = re.compile(r'--(?!(-)*>)')
 match_tag_prefix_and_name = re.compile(
     r'^(?P<prefix></?)(?P<name>([^:\n\r ]+:)?[^ \n\t\r>/]+)'
@@ -226,7 +234,8 @@ class ElementParser(object):
         namespace = self.namespaces[-1].copy()
         self.namespaces.append(namespace)
         node = parse_tag(token, namespace, self.restricted_namespace)
-        self.index.append((node['name'], len(self.queue)))
+        if node['name'].lower() not in EMPTY_HTML_TAGS:
+            self.index.append((node['name'], len(self.queue)))
         return kind, (node, )
 
     def visit_end_tag(self, kind, token):

--- a/src/chameleon/parser.py
+++ b/src/chameleon/parser.py
@@ -244,6 +244,8 @@ class ElementParser(object):
                 children = self.queue[pos:]
                 del self.queue[pos:]
                 break
+            else:
+                raise ParseError('No closing tag.', name)
         else:
             raise ParseError("Unexpected end tag.", token)
 

--- a/src/chameleon/program.py
+++ b/src/chameleon/program.py
@@ -3,6 +3,7 @@ try:
 except NameError:
     long = int
 
+from .exc import ParseError
 from .tokenize import iter_xml
 from .tokenize import iter_text
 from .parser import ElementParser
@@ -35,6 +36,14 @@ class ElementProgram(object):
             node = self.visit(kind, args)
             if node is not None:
                 self.body.append(node)
+
+        if parser.index:
+            # The ``index`` attribute contains a sequence of open HTML tags
+            # which get consumed as their closing tags are found. If the
+            # sequence contains any values after parsing then the template has
+            # unclosed tags.
+            name, pos = parser.index.pop()
+            raise ParseError('No closing tag.', name)
 
     def visit(self, kind, args):
         visitor = getattr(self, "visit_%s" % kind)

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -656,6 +656,28 @@ class ZopePageTemplatesTest(RenderTestCase):
             rendered = template(sin=sin, a=pi)
             self.assertEqual('sin(3.141592653589793) is 1.2', rendered)
 
+    def test_windows_line_endings(self):
+        template = self.from_string('<span id="span_id"\r\n'
+                                    '      class="foo"\r\n'
+                                    '      tal:content="string:bar"/>')
+        self.assertEqual(template(),
+                         '<span id="span_id"\r\n'
+                         '      class="foo">bar</span>')
+
+    def test_unclosed_tags(self):
+        from chameleon.exc import ParseError
+
+        data = '<tal:define define="x 1"><span tal:content="x"/>'
+        self.assertRaises(ParseError, self.from_string, data)
+
+        data = ('<p tal:define="x 1"><BR clear="all"><hr>'
+                '<span tal:replace="x"/></p>')
+        template = self.from_string(data)
+        self.assertEqual(template(), '<p><BR clear="all"><hr>1</p>')
+
+        data = '<a href="foo"><p tal:define="x 1"><span tal:replace="x"/></p>'
+        self.assertRaises(ParseError, self.from_string, data)
+
 
 class ZopeTemplatesTestSuite(RenderTestCase):
     def setUp(self):

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -678,6 +678,11 @@ class ZopePageTemplatesTest(RenderTestCase):
         data = '<a href="foo"><p tal:define="x 1"><span tal:replace="x"/></p>'
         self.assertRaises(ParseError, self.from_string, data)
 
+        data = ('<a href="foo">'
+                '<p tal:define="x 1"><span tal:replace="x"/></p></a>')
+        template = self.from_string(data)
+        self.assertEqual(template(), '<a href="foo"><p>1</p></a>')
+
 
 class ZopeTemplatesTestSuite(RenderTestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #327

@d-maurer This is a draft as food for discussion on a fix for #327. The code change will flag up any unclosed tag - but is that really desirable? As the failing test shows it will also flag up simple tags that few people close, like `<br>`.  But it feels a fix shouldn't introduce code to introspect the unclosed tag to see if it's OK to ignore it.