### PR TITLE
Avoid various traceback reference cycles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 3.9.1 (unreleased)
 ------------------
 
+- Avoid various traceback reference cycles.
+
 3.9.0 (2021-02-26)
 ------------------
 

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -780,11 +780,10 @@ class ExpressionTransform(object):
 
         try:
             stmts = self.translate(expression, target)
-        except ExpressionError:
+        except ExpressionError as exc:
             if self.strict:
                 raise
 
-            exc = sys.exc_info()[1]
             p = pickle.dumps(exc, -1)
 
             stmts = template(

--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -267,8 +267,7 @@ class PythonExpr(TalesExpr):
 
         try:
             value = self.parse(string)
-        except SyntaxError:
-            exc = sys.exc_info()[1]
+        except SyntaxError as exc:
             raise ExpressionError(exc.msg, string)
 
         # Transform attribute lookups to allow fallback to item lookup
@@ -558,8 +557,7 @@ class ExpressionParser(object):
 
         try:
             factory = self.factories[prefix]
-        except KeyError:
-            exc = sys.exc_info()[1]
+        except KeyError as exc:
             raise LookupError(
                 "Unknown expression type: %s." % str(exc)
                 )

--- a/src/chameleon/template.py
+++ b/src/chameleon/template.py
@@ -194,26 +194,29 @@ class BaseTemplate(object):
             raise
         except:
             cls, exc, tb = sys.exc_info()
-            errors = rcontext.get('__error__')
-            if errors:
-                formatter = exc.__str__
-                if isinstance(formatter, ExceptionFormatter):
-                    if errors is not formatter._errors:
-                        formatter._errors.extend(errors)
-                    raise
+            try:
+                errors = rcontext.get('__error__')
+                if errors:
+                    formatter = exc.__str__
+                    if isinstance(formatter, ExceptionFormatter):
+                        if errors is not formatter._errors:
+                            formatter._errors.extend(errors)
+                        raise
 
-                formatter = ExceptionFormatter(errors, econtext, rcontext, self.value_repr)
+                    formatter = ExceptionFormatter(errors, econtext, rcontext, self.value_repr)
 
-                try:
-                    exc = create_formatted_exception(
-                        exc, cls, formatter, RenderError
-                    )
-                except TypeError:
-                    pass
+                    try:
+                        exc = create_formatted_exception(
+                            exc, cls, formatter, RenderError
+                        )
+                    except TypeError:
+                        pass
 
-                raise_with_traceback(exc, tb)
+                    raise_with_traceback(exc, tb)
 
-            raise
+                raise
+            finally:
+                del exc, tb
 
         return join(stream)
 
@@ -246,8 +249,7 @@ class BaseTemplate(object):
                 if self.keep_source:
                     self.source = source
                 cooked = self.loader.build(source, filename)
-            except TemplateError:
-                exc = sys.exc_info()[1]
+            except TemplateError as exc:
                 exc.token.filename = self.filename
                 raise
         elif self.keep_source:

--- a/src/chameleon/tests/test_parser.py
+++ b/src/chameleon/tests/test_parser.py
@@ -1,7 +1,5 @@
 from __future__ import with_statement
 
-import sys
-
 from unittest import TestCase
 
 from ..namespaces import XML_NS
@@ -35,8 +33,7 @@ class ParserTest(TestCase):
             from ..utils import read_encoded
             try:
                 want = read_encoded(source)
-            except UnicodeDecodeError:
-                exc = sys.exc_info()[1]
+            except UnicodeDecodeError as exc:
                 self.fail("%s - %s" % (exc, filename))
 
             from ..tokenize import iter_xml

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -101,8 +101,7 @@ class TemplateFileTestCase(TestCase):
         template = self._class("___does_not_exist___")
         try:
             template.cook_check()
-        except IOError:
-            exc = sys.exc_info()[1]
+        except IOError as exc:
             self.assertEqual(
                 os.getcwd(),
                 os.path.dirname(exc.filename)
@@ -172,8 +171,7 @@ class ZopePageTemplatesTest(RenderTestCase):
                 from chameleon.exc import TemplateError
                 try:
                     template = self.from_string(body)
-                except TemplateError:
-                    exc = sys.exc_info()[1]
+                except TemplateError as exc:
                     return func(self, body, exc)
                 else:
                     self.fail("Expected exception.")
@@ -199,8 +197,7 @@ class ZopePageTemplatesTest(RenderTestCase):
 
         try:
             template()
-        except ExpressionError:
-            exc = sys.exc_info()[1]
+        except ExpressionError as exc:
             self.assertTrue(body[exc.offset:].startswith('bad ///'))
         else:
             self.fail("Expected exception")
@@ -215,8 +212,7 @@ class ZopePageTemplatesTest(RenderTestCase):
         template = self.from_string(body, strict=False)
         try:
             template()
-        except RenderError:
-            exc = sys.exc_info()[1]
+        except RenderError as exc:
             self.assertNotIn('var_does_not_exists', str(exc))
         else:
             self.fail("Expected exception")
@@ -240,8 +236,7 @@ class ZopePageTemplatesTest(RenderTestCase):
             ''')
         try:
             result = template(macro=macro_wrap, macro_inner=macro_inner)
-        except RenderError:
-            exc = sys.exc_info()[1]
+        except RenderError as exc:
             self.assertTrue(isinstance(exc, KeyError))
             self.assertIn(''''key-does-not-exist'
 
@@ -264,8 +259,7 @@ class ZopePageTemplatesTest(RenderTestCase):
 
         try:
             template()
-        except RenderError:
-            exc = sys.exc_info()[1]
+        except RenderError as exc:
             self.assertTrue(isinstance(exc, AttributeError))
             self.assertIn('bad', str(exc))
         else:
@@ -341,8 +335,7 @@ class ZopePageTemplatesTest(RenderTestCase):
 
         try:
             template(name=name)
-        except UnicodeDecodeError:
-            exc = sys.exc_info()[1]
+        except UnicodeDecodeError as exc:
             formatted = str(exc)
 
             # There's a marker under the expression that has the
@@ -467,7 +460,6 @@ class ZopePageTemplatesTest(RenderTestCase):
             template()
         except Exception as exc:
             self.assertIn(RenderError, type(exc).__bases__)
-            exc = sys.exc_info()[1]
             formatted = str(exc)
             self.assertFalse('NameError:' in formatted)
             self.assertTrue('foo' in formatted)
@@ -522,9 +514,8 @@ class ZopePageTemplatesTest(RenderTestCase):
         template._render = _render
         try:
             template()
-        except TestException:
+        except TestException as exc:
             self.assertEqual(calls, [(('foo', ), {'bar': 'baz'})])
-            exc = sys.exc_info()[1]
             formatted = str(exc)
             self.assertTrue('TestException' in formatted)
             self.assertTrue('"expression"' in formatted)
@@ -643,8 +634,7 @@ class ZopePageTemplatesTest(RenderTestCase):
             <div metal:fill-slot="name"></dav>
             </div>
             """)
-        except ParseError:
-            exc = sys.exc_info()[1]
+        except ParseError as exc:
             self.assertTrue("</dav>" in str(exc))
         else:
             self.fail("Expected error.")

--- a/src/chameleon/tests/test_tokenizer.py
+++ b/src/chameleon/tests/test_tokenizer.py
@@ -18,8 +18,7 @@ class TokenizerTest(TestCase):
             from ..utils import read_encoded
             try:
                 want = read_encoded(source)
-            except UnicodeDecodeError:
-                exc = sys.exc_info()[1]
+            except UnicodeDecodeError as exc:
                 self.fail("%s - %s" % (exc, filename))
 
             from ..tokenize import iter_xml

--- a/src/chameleon/utils.py
+++ b/src/chameleon/utils.py
@@ -470,8 +470,7 @@ class ImportableMarker(object):
 def lookup_attr(obj, key):
     try:
         return getattr(obj, key)
-    except AttributeError:
-        exc = sys.exc_info()[1]
+    except AttributeError as exc:
         try:
             get = obj.__getitem__
         except AttributeError:


### PR DESCRIPTION
In Python 3, exceptions have a ``__traceback__`` attribute containing
their associated traceback.  Storing an exception in a local variable of
a frame present in that traceback thus creates a reference cycle.  Avoid
this either by explicitly deleting the exception value when we're
finished with it, or by using the simpler ``except ... as`` construction
(since Python 3 automatically clears the exception at the end of the
``except`` clause in that case).