### PR TITLE
Fix typos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,7 +96,7 @@ Changes
 3.7.1 (2020-05-10)
 ------------------
 
-- Fix compatiblity issue with Python 3.9.
+- Fix compatibility issue with Python 3.9.
 
 
 3.7.0 (2020-03-26)
@@ -670,7 +670,7 @@ Bugfixes:
 ------------------
 
 - The error handler now invokes the ``__init__`` method of
-  ``BaseException`` instead of the possibly overriden method (which
+  ``BaseException`` instead of the possibly overridden method (which
   may take required arguments). This fixes issue #97.
   [j23d, malthe]
 
@@ -1092,7 +1092,7 @@ Bugfixes:
 - Fixed an issue where assignment to a variable ``"type"`` would
   fail. This fixes issue #40.
 
-- Fixed an issue where an (unsuccesful) assignment for a repeat loop
+- Fixed an issue where an (unsuccessful) assignment for a repeat loop
   to a compiler internal name would not result in an error.
 
 - If the translation function returns the identical object, manually
@@ -1231,7 +1231,7 @@ Incompatibilities:
 
 Bugfixes:
 
-- The file-based template class no longer verifies the existance of a
+- The file-based template class no longer verifies the existence of a
   template file (using ``os.lstat``). This now happens implicitly if
   eager parsing is enabled, or otherwise when first needed (e.g. at
   render time).
@@ -1322,7 +1322,7 @@ Bugfixes:
 
 Features:
 
-- The ``RepeatDict`` class now works as a proxy behind a seperate
+- The ``RepeatDict`` class now works as a proxy behind a separate
   dictionary instance.
 
 - Added template constructor option ``keep_body`` which is a flag

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -40,7 +40,7 @@ The majority of the code in Chameleon is supplied under this license:
     SUCH DAMAGE.
 
 Portions of the code in Chameleon are supplied under the ZPL (headers
-within individiual files indicate that these portions are licensed
+within individual files indicate that these portions are licensed
 under the ZPL):
 
   Zope Public License (ZPL) Version 2.1
@@ -99,7 +99,7 @@ under the ZPL):
     DAMAGE.
 
 Portions of the code in Chameleon are supplied under the BSD license
-(headers within individiual files indicate that these portions are
+(headers within individual files indicate that these portions are
 licensed under this license):
 
   All rights reserved.
@@ -132,7 +132,7 @@ licensed under this license):
 
 
 Portions of the code in Chameleon are supplied under the Python
-License (headers within individiual files indicate that these portions
+License (headers within individual files indicate that these portions
 are licensed under this license):
 
   PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2

--- a/benchmarks/bm_mako.py
+++ b/benchmarks/bm_mako.py
@@ -5,7 +5,7 @@ Benchmark for test the performance of Mako templates engine.
 Includes:
     -two template inherences
     -HTML escaping, XML escaping, URL escaping, whitespace trimming
-    -function defitions and calls
+    -function definitions and calls
     -forloops
 """
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -879,7 +879,7 @@ Additionally, macros are always fully expanded, even in a template's
 source text, so that the template appears very similar to its final
 rendering.
 
-A single Page Template can accomodate multiple macros.
+A single Page Template can accommodate multiple macros.
 
 Namespace
 ~~~~~~~~~
@@ -1345,7 +1345,7 @@ Note that the value of the particular attributes come either from the
 HTML attribute value itself or from the data inserted by
 ``tal:attributes``.
 
-If an attibute is to be both computed using ``tal:attributes`` and
+If an attribute is to be both computed using ``tal:attributes`` and
 translated, the translation service is passed the result of the TALES
 expression for that attribute.
 

--- a/src/chameleon/exc.py
+++ b/src/chameleon/exc.py
@@ -33,7 +33,7 @@ def compute_source_marker(line, column, expression, size):
           ^^^
 
     The entire expression is always shown, even if ``size`` does not
-    accomodate for it.
+    accommodate for it.
 
     >>> test('  foo bar baz  ', 6, 'bar baz', 10)
     ··· oo bar baz

--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -249,7 +249,7 @@ class PythonExpr(TalesExpr):
         # Strip spaces
         string = expression.strip()
 
-        # Conver line continuations to newlines
+        # Convert line continuations to newlines
         string = substitute(re_continuation, '\n', string)
 
         # Convert newlines to spaces
@@ -427,7 +427,7 @@ class StringExpr:
     dummy engine which just returns the input as a string.
 
     As an example, we'll implement an expression engine which
-    instead counts the number of characters in the expresion and
+    instead counts the number of characters in the expression and
     returns an integer result.
 
     >>> class engine:

--- a/src/chameleon/tests/test_exc.py
+++ b/src/chameleon/tests/test_exc.py
@@ -16,7 +16,7 @@ class TestTemplateError(TestCase):
             'No location data found\n%s' % s)
 
     def test_umlaut_exc_to_string(self):
-        # test if an exception is convertable to a string
+        # test if an exception is convertible to a string
         body = '<p>uumlaut:\xfc</p>'
         string = body[3:-4]
         token = tokenize.Token(string, 3, body)


### PR DESCRIPTION
Found via `codespell -S .tox,*.pt -L nam,varius`