### PR TITLE
Boolean attributes ($-expression and dynamic)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,10 @@ Changes
 
 In next release ...
 
--
+- Boolean attributes (those configured using the optional
+  `boolean_attributes` parameter) now correctly work with $-expression
+  interpolation. Additionally, dynamic attributes now respect the
+  boolean attributes configuration as well.
 
 4.0.1 (2023-06-19)
 ------------------

--- a/src/chameleon/nodes.py
+++ b/src/chameleon/nodes.py
@@ -49,9 +49,12 @@ class Value(Node):
 class Substitution(Value):
     """Expression value for text substitution."""
 
-    _fields = "value", "char_escape", "default", "default_marker"
+    _fields = (
+        "value", "char_escape", "default", "default_marker", "literal_false"
+    )
 
     default = None
+    literal_false = True
 
 
 class Boolean(Value):
@@ -73,7 +76,7 @@ class Element(Node):
 class DictAttributes(Node):
     """Element attributes from one or more Python dicts."""
 
-    _fields = "expression", "char_escape", "quote", "exclude"
+    _fields = "expression", "char_escape", "quote", "exclude", "bool_names"
 
 
 class Attribute(Node):
@@ -209,6 +212,12 @@ class Interpolation(Node):
 
     _fields = (
         "value", "braces_required", "translation", "default", "default_marker")
+
+
+class Replace(Node):
+    """Replace non-empty value with string."""
+
+    _fields = "value", "s"
 
 
 class Translate(Node):

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -568,32 +568,41 @@ class ZopePageTemplatesTest(RenderTestCase):
 
     def test_boolean_attributes(self):
         template = self.from_string(
-            '<input type="input" tal:attributes="checked False" />'
-            '<input type="input" tal:attributes="checked True" />'
-            '<input type="input" tal:attributes="checked None" />'
-            '<input type="input" tal:attributes="checked \'\'" />'
-            '<input type="input" tal:attributes="checked default" />'
-            '<input type="input" tal:attributes="dynamic_true" />'
-            '<input type="input" tal:attributes="dynamic_false" />'
-            '<input type="input" checked="${True}" />'
-            '<input type="input" checked="${False}" />'
-            '<input type="input" checked="checked" tal:attributes="checked default" />',  # noqa: E501 line too long
+            "\n".join((
+                '<input type="input" tal:attributes="checked False" />',
+                '<input type="input" tal:attributes="checked True" />',
+                '<input type="input" tal:attributes="checked None" />',
+                '<input type="input" tal:attributes="checked \'\'" />',
+                '<input type="input" tal:attributes="checked default" />',
+                '<input type="input" tal:attributes="dynamic_true" />',
+                '<input type="input" tal:attributes="dynamic_false" />',
+                '<input type="input" checked="${True}" />',
+                '<input type="input" checked="${False}" />',
+                '<input type="input" checked="${[]}" />',
+                '<input type="input" checked="checked" tal:attributes="checked default" />',  # noqa: E501 line too long
+            )),
             boolean_attributes={
                 'checked'})
 
         self.assertEqual(
-            template(dynamic_true={"checked": True}, dynamic_true={"checked": False}),
-            '<input type="input" />'
-            '<input type="input" checked="checked" />'
-            '<input type="input" />'
-            '<input type="input" />'
-            '<input type="input" />'
-            '<input type="input" checked="checked" />'
-            '<input type="input" />'
-            '<input type="input" checked="checked" />'
-            '<input type="input" />'
-            '<input type="input" checked="checked" />',
-            template.source
+            template(
+                dynamic_true={"checked": True},
+                dynamic_false={"checked": False}
+            ),
+            "\n".join((
+                '<input type="input" />',
+                '<input type="input" checked="checked" />',
+                '<input type="input" />',
+                '<input type="input" />',
+                '<input type="input" />',
+                '<input type="input" checked="checked" />',
+                '<input type="input" />',
+                '<input type="input" checked="checked" />',
+                '<input type="input" />',
+                '<input type="input" />',
+                '<input type="input" checked="checked" />',
+            )),
+            "Output mismatch\n" + template.source
         )
 
     def test_default_debug_flag(self):

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -573,16 +573,24 @@ class ZopePageTemplatesTest(RenderTestCase):
             '<input type="input" tal:attributes="checked None" />'
             '<input type="input" tal:attributes="checked \'\'" />'
             '<input type="input" tal:attributes="checked default" />'
+            '<input type="input" tal:attributes="dynamic_true" />'
+            '<input type="input" tal:attributes="dynamic_false" />'
+            '<input type="input" checked="${True}" />'
+            '<input type="input" checked="${False}" />'
             '<input type="input" checked="checked" tal:attributes="checked default" />',  # noqa: E501 line too long
             boolean_attributes={
                 'checked'})
 
         self.assertEqual(
-            template(),
+            template(dynamic_true={"checked": True}, dynamic_true={"checked": False}),
             '<input type="input" />'
             '<input type="input" checked="checked" />'
             '<input type="input" />'
             '<input type="input" />'
+            '<input type="input" />'
+            '<input type="input" checked="checked" />'
+            '<input type="input" />'
+            '<input type="input" checked="checked" />'
             '<input type="input" />'
             '<input type="input" checked="checked" />',
             template.source


### PR DESCRIPTION
While handling boolean attributes (previously a configuration known as _literal false_ – or rather the opposite of that) previously supported $-expressions such as `checked="${some_condition}"`, this behavior was accidentally changed in 3.8.0.

This has now been fixed.

Additionally, boolean attributes are now respected for dynamic attributes.

This closes issue #381.