### PR TITLE
Demonstration of my assertion that boolean_attributes shouldn't be honored when the template is XML

### DIFF
--- a/src/chameleon/template.py
+++ b/src/chameleon/template.py
@@ -18,6 +18,7 @@ from .loader import ModuleLoader
 from .nodes import Module
 from .utils import DebuggingOutputStream
 from .utils import Scope
+from .utils import detect_encoding
 from .utils import create_formatted_exception
 from .utils import join
 from .utils import mangle
@@ -225,8 +226,12 @@ class BaseTemplate:
                 body, self.default_encoding
             )
         else:
-            content_type = body.startswith('<?xml')
-            encoding = None
+            content_type, encoding = detect_encoding(
+                body, self.default_encoding
+                )
+
+            if body.startswith('<?xml'):
+                content_type = 'text/xml'
 
         self.content_type = content_type
         self.content_encoding = encoding

--- a/src/chameleon/tests/test_bools_plus_sniffing.py
+++ b/src/chameleon/tests/test_bools_plus_sniffing.py
@@ -1,0 +1,392 @@
+import difflib
+import unittest
+
+from chameleon import PageTemplate
+
+boolean_html_attributes= [
+        # From http://www.w3.org/TR/xhtml1/#guidelines (C.10)
+        "compact",
+        "nowrap",
+        "ismap",
+        "declare",
+        "noshade",
+        "checked",
+        "disabled",
+        "readonly",
+        "multiple",
+        "selected",
+        "noresize",
+        "defer",
+    ]
+
+xml_bytes = b"""\
+<?xml version="1.0" ?>
+<input type="checkbox" checked="nope" tal:attributes="checked checked" />
+<input type="checkbox" checked="${checked}" />
+"""
+
+xml_w_enc_bytes = b"""\
+<?xml version="1.0" encoding="ascii" ?>
+<input type="checkbox" checked="nope" tal:attributes="checked checked" />
+<input type="checkbox" checked="${checked}" />
+"""
+
+html5_bytes = b"""\
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Title of document</title>
+</head>
+<body>
+  <form>
+    <input type="checkbox" checked="nope"
+           tal:attributes="checked checked" />
+    <input type="checkbox" checked="${checked}" />
+  </form>
+</body>
+</html>
+"""
+
+html5_w_ct_n_enc_bytes = b"""\
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="foo/bar; charset=utf-8" />
+  <title>Title of document</title>
+</head>
+<body>
+  <form>
+    <input type="checkbox" checked="nope"
+           tal:attributes="checked checked" />
+    <input type="checkbox" checked="${checked}" />
+  </form>
+</body>
+</html>
+"""
+
+class BaseTestCase(unittest.TestCase):
+    def get_template(self, text):
+        template = PageTemplate(
+            text,
+            boolean_attributes=boolean_html_attributes
+        )
+        return template
+
+    def get_template_bytes(self):
+        return self.get_template(self.input_bytes)
+
+    def get_template_str(self):
+        return self.get_template(self.input_bytes.decode('utf-8'))
+
+    def assert_same(self, s1, s2):
+        L1 = s1.splitlines()
+        L1 = list(filter(None, [ ' '.join(x.split()).strip() for x in L1 ]))
+        L2 = s2.splitlines()
+        L2 = list(filter(None, [ ' '.join(x.split()).strip() for x in L2 ]))
+        diff = '\n'.join(list(difflib.unified_diff(L1, L2)))
+        assert diff == '', diff
+
+class XMLTestCase(BaseTestCase):
+
+    input_bytes = xml_bytes
+
+    def test_bytes_content_type(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.content_type, 'text/xml')
+
+    def test_bytes_encoding(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.encoding, None)
+
+    def test_str_content_type(self):
+        template = self.get_template_str()
+        self.assertEqual(template.content_type, 'text/xml')
+
+    def test_str_encoding(self):
+        template = self.get_template_str()
+        self.assertEqual(template.encoding, None)
+
+    def test_bytes_checked_true(self):
+        template = self.get_template_bytes()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="True" />
+        <input type="checkbox" checked="True" />
+        """
+        result = template(checked=True)
+        self.assert_same(expected, result)
+        
+    def test_bytes_checked_false(self):
+        template = self.get_template_bytes()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="False" />
+        <input type="checkbox" checked="False" />
+        """
+        result = template(checked=False)
+        self.assert_same(expected, result)
+
+    def test_bytes_checked_None(self):
+        template = self.get_template_bytes()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" />
+        <input type="checkbox" />
+        """
+        result = template(checked=None)
+        self.assert_same(expected, result)
+        
+    def test_bytes_checked_default(self):
+        template = self.get_template_bytes()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="nope" />
+        <input type="checkbox" />
+        """
+        result = template(checked=template.default_marker)
+        self.assert_same(expected, result)
+
+    def test_str_checked_true(self):
+        template = self.get_template_str()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="True" />
+        <input type="checkbox" checked="True" />
+        """
+        result = template(checked=True)
+        self.assert_same(expected, result)
+        
+    def test_str_checked_false(self):
+        template = self.get_template_str()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="False" />
+        <input type="checkbox" checked="False" />
+        """
+        result = template(checked=False)
+        self.assert_same(expected, result)
+
+    def test_str_checked_None(self):
+        template = self.get_template_str()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" />
+        <input type="checkbox" />
+        """
+        result = template(checked=None)
+        self.assert_same(expected, result)
+        
+    def test_str_checked_default(self):
+        template = self.get_template_str()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="nope" />
+        <input type="checkbox" />
+        """
+        result = template(checked=template.default_marker)
+        self.assert_same(expected, result)
+        
+class XMLWithEncodingTestCase(BaseTestCase):
+
+    input_bytes = xml_w_enc_bytes
+
+    def test_bytes_encoding(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.encoding, 'ascii')
+    
+    def test_str_encoding(self):
+        template = self.get_template_str()
+        self.assertEqual(template.encoding, 'ascii')
+
+class HTML5TestCase(BaseTestCase):
+
+    input_bytes = html5_bytes
+
+    def test_bytes_content_type(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.content_type, None)
+
+    def test_bytes_encoding(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.encoding, None)
+
+    def test_str_content_type(self):
+        template = self.get_template_str()
+        self.assertEqual(template.content_type, None)
+
+    def test_str_encoding(self):
+        template = self.get_template_str()
+        self.assertEqual(template.encoding, None)
+
+    def test_bytes_checked_true(self):
+        template = self.get_template_bytes()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" checked="checked" />
+            <input type="checkbox" checked="checked" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=True)
+        self.assert_same(expected, result)
+        
+    def test_bytes_checked_false(self):
+        template = self.get_template_bytes()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" />
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=False)
+        self.assert_same(expected, result)
+
+    def test_bytes_checked_None(self):
+        template = self.get_template_bytes()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" />
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=None)
+        self.assert_same(expected, result)
+        
+    def test_bytes_checked_default(self):
+        template = self.get_template_bytes()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" checked="nope"/>
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=template.default_marker)
+        self.assert_same(expected, result)
+
+    def test_str_checked_true(self):
+        template = self.get_template_str()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" checked="checked" />
+            <input type="checkbox" checked="checked" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=True)
+        self.assert_same(expected, result)
+        
+    def test_str_checked_false(self):
+        template = self.get_template_str()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" />
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=False)
+        self.assert_same(expected, result)
+
+    def test_str_checked_None(self):
+        template = self.get_template_str()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" />
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=None)
+        self.assert_same(expected, result)
+        
+    def test_str_checked_default(self):
+        template = self.get_template_str()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" checked="nope" />
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=template.default_marker)
+        self.assert_same(expected, result)
+
+class HTML5WithContentTypeAndEncodingTestCase(BaseTestCase):
+
+    input_bytes = html5_w_ct_n_enc_bytes
+
+    def test_bytes_content_type(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.encoding, 'foo/bar')
+    
+    def test_bytes_encoding(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.encoding, 'utf-8')
+    
+    def test_str_content_type(self):
+        template = self.get_template_str()
+        self.assertEqual(template.encoding, 'foo/bar')
+
+    def test_str_encoding(self):
+        template = self.get_template_str()
+        self.assertEqual(template.encoding, 'utf-8')
+


### PR DESCRIPTION
This PR is not meant to be merged into master as-is because it contains failing tests.  It's basically a set of tests that assert my understanding of how booleans and content type sniffing should work together.   

I gotta admit that I'm asserting behavior in those tests that I believe is correct, but it's a bit unclear to me how things *should* work.  I could be asserting the wrong thing in some cases.

The behavior I'm asserting is that "boolean_attributes" should be ignored when the input is XML.  This seems to make sense to me because XML by definition doesn't have the strange kind of valueless boolean attributes that HTML does.  That said, I'm not sure whether boolean_attributes are useful in an XML context for other reasons (I doubt it).

The tests also demonstrate that in many circumstances the correct (or at least my assertion of correct)  encoding and content-type are not detected by sniffing.  The tests also demonstrate  a number of other questionable behaviors related to booleans, even in non-XML cases.

The PR also contains a best-effort fix for a bug related to setting content_type on a template instance, but that's only incidental in this case and doesn't really help much overall. 

I'm a little leery about submitting this and seeing a very backwards incompatible change come as a result.  I can imagine myself wanting to rearchitect so the code doesn't do much sniffing at all, and just have explicit HTMLTemplate and XMLTemplate classes.  But I hope some middle ground can be reached where the code exhibits the right behavior and also maintains b/w compat for some time.

Anyway, I hope you can take a look Malthe, and thanks for any attention.