### PR TITLE
Automatically configure boolean attributes for non-XML documents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,12 @@ Changes
 
 In next release ...
 
--
+- Boolean attributes are now automatically configured for templates in
+  non-XML mode, presuming that we're being used to generate HTML.
+
+  This means that the same loading mechanism can be used for both XML-
+  and HTML-based templates.
+
 
 4.1.0 (2023-08-29)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Changes
 
 In next release ...
 
+- An XML document provided as a string (i.e. decoded) now correctly
+  has its content encoding parsed.
+
 - Boolean attributes are now automatically configured for templates in
   non-XML mode, presuming that we're being used to generate HTML.
 

--- a/src/chameleon/template.py
+++ b/src/chameleon/template.py
@@ -24,6 +24,7 @@ from .utils import join
 from .utils import mangle
 from .utils import raise_with_traceback
 from .utils import read_bytes
+from .utils import read_xml_encoding
 from .utils import value_repr
 
 
@@ -228,7 +229,7 @@ class BaseTemplate:
             )
         elif body.startswith('<?xml'):
             content_type = 'text/xml'
-            encoding = None
+            encoding = read_xml_encoding(body.encode("utf-8"))
         else:
             content_type, encoding = detect_encoding(
                 body, self.default_encoding

--- a/src/chameleon/tests/outputs/028.pt
+++ b/src/chameleon/tests/outputs/028.pt
@@ -1,5 +1,5 @@
 <div xmlns="http://www.w3.org/1999/xhtml">
-  <option selected="True"></option>
-  <option selected="False"></option>
+  <option selected="selected"></option>
+  <option></option>
   <option></option>
 </div>

--- a/src/chameleon/tests/outputs/071.pt
+++ b/src/chameleon/tests/outputs/071.pt
@@ -1,7 +1,7 @@
 <html>
   <body>
-    <input type="input" checked="True" />
-    <input type="input" checked="False" />
+    <input type="input" checked="checked" />
+    <input type="input" />
     <input type="input" />
     <input type="input" checked="checked" />
     <input type="input" checked />

--- a/src/chameleon/tests/test_bools_plus_sniffing.py
+++ b/src/chameleon/tests/test_bools_plus_sniffing.py
@@ -3,22 +3,6 @@ import unittest
 
 from chameleon import PageTemplate
 
-boolean_html_attributes= [
-        # From http://www.w3.org/TR/xhtml1/#guidelines (C.10)
-        "compact",
-        "nowrap",
-        "ismap",
-        "declare",
-        "noshade",
-        "checked",
-        "disabled",
-        "readonly",
-        "multiple",
-        "selected",
-        "noresize",
-        "defer",
-    ]
-
 xml_bytes = b"""\
 <?xml version="1.0" ?>
 <input type="checkbox" checked="nope" tal:attributes="checked checked" />
@@ -66,10 +50,7 @@ html5_w_ct_n_enc_bytes = b"""\
 
 class BaseTestCase(unittest.TestCase):
     def get_template(self, text):
-        template = PageTemplate(
-            text,
-            boolean_attributes=boolean_html_attributes
-        )
+        template = PageTemplate(text)
         return template
 
     def get_template_bytes(self):
@@ -89,6 +70,7 @@ class BaseTestCase(unittest.TestCase):
 class XMLTestCase(BaseTestCase):
 
     input_bytes = xml_bytes
+    encoding = None
 
     def test_bytes_content_type(self):
         template = self.get_template_bytes()
@@ -96,7 +78,7 @@ class XMLTestCase(BaseTestCase):
 
     def test_bytes_encoding(self):
         template = self.get_template_bytes()
-        self.assertEqual(template.encoding, None)
+        self.assertEqual(template.content_encoding, 'utf-8')
 
     def test_str_content_type(self):
         template = self.get_template_str()
@@ -104,7 +86,7 @@ class XMLTestCase(BaseTestCase):
 
     def test_str_encoding(self):
         template = self.get_template_str()
-        self.assertEqual(template.encoding, None)
+        self.assertEqual(template.content_encoding, self.encoding)
 
     def test_bytes_checked_true(self):
         template = self.get_template_bytes()
@@ -143,7 +125,7 @@ class XMLTestCase(BaseTestCase):
         <input type="checkbox" checked="nope" />
         <input type="checkbox" />
         """
-        result = template(checked=template.default_marker)
+        result = template(checked=template.default_marker.value)
         self.assert_same(expected, result)
 
     def test_str_checked_true(self):
@@ -183,20 +165,21 @@ class XMLTestCase(BaseTestCase):
         <input type="checkbox" checked="nope" />
         <input type="checkbox" />
         """
-        result = template(checked=template.default_marker)
+        result = template(checked=template.default_marker.value)
         self.assert_same(expected, result)
         
 class XMLWithEncodingTestCase(BaseTestCase):
 
     input_bytes = xml_w_enc_bytes
+    encoding = 'ascii'
 
     def test_bytes_encoding(self):
         template = self.get_template_bytes()
-        self.assertEqual(template.encoding, 'ascii')
+        self.assertEqual(template.content_encoding, self.encoding)
     
     def test_str_encoding(self):
         template = self.get_template_str()
-        self.assertEqual(template.encoding, 'ascii')
+        self.assertEqual(template.content_encoding, self.encoding)
 
 class HTML5TestCase(BaseTestCase):
 
@@ -204,19 +187,19 @@ class HTML5TestCase(BaseTestCase):
 
     def test_bytes_content_type(self):
         template = self.get_template_bytes()
-        self.assertEqual(template.content_type, None)
+        self.assertEqual(template.content_type, 'text/html')
 
     def test_bytes_encoding(self):
         template = self.get_template_bytes()
-        self.assertEqual(template.encoding, None)
+        self.assertEqual(template.content_encoding, 'utf-8')
 
     def test_str_content_type(self):
         template = self.get_template_str()
-        self.assertEqual(template.content_type, None)
+        self.assertEqual(template.content_type, 'text/html')
 
     def test_str_encoding(self):
         template = self.get_template_str()
-        self.assertEqual(template.encoding, None)
+        self.assertEqual(template.content_encoding, 'utf-8')
 
     def test_bytes_checked_true(self):
         template = self.get_template_bytes()
@@ -285,13 +268,13 @@ class HTML5TestCase(BaseTestCase):
         </head>
         <body>
           <form>
-            <input type="checkbox" checked="nope"/>
+            <input type="checkbox" checked="nope" />
             <input type="checkbox" />
           </form>
         </body>
         </html>
         """
-        result = template(checked=template.default_marker)
+        result = template(checked=template.default_marker.value)
         self.assert_same(expected, result)
 
     def test_str_checked_true(self):
@@ -367,7 +350,7 @@ class HTML5TestCase(BaseTestCase):
         </body>
         </html>
         """
-        result = template(checked=template.default_marker)
+        result = template(checked=template.default_marker.value)
         self.assert_same(expected, result)
 
 class HTML5WithContentTypeAndEncodingTestCase(BaseTestCase):
@@ -376,17 +359,17 @@ class HTML5WithContentTypeAndEncodingTestCase(BaseTestCase):
 
     def test_bytes_content_type(self):
         template = self.get_template_bytes()
-        self.assertEqual(template.encoding, 'foo/bar')
+        self.assertEqual(template.content_type, 'foo/bar')
     
     def test_bytes_encoding(self):
         template = self.get_template_bytes()
-        self.assertEqual(template.encoding, 'utf-8')
+        self.assertEqual(template.content_encoding, 'utf-8')
     
     def test_str_content_type(self):
         template = self.get_template_str()
-        self.assertEqual(template.encoding, 'foo/bar')
+        self.assertEqual(template.content_type, 'foo/bar')
 
     def test_str_encoding(self):
         template = self.get_template_str()
-        self.assertEqual(template.encoding, 'utf-8')
+        self.assertEqual(template.content_encoding, 'utf-8')
 

--- a/src/chameleon/tests/test_bools_plus_sniffing.py
+++ b/src/chameleon/tests/test_bools_plus_sniffing.py
@@ -49,6 +49,7 @@ html5_w_ct_n_enc_bytes = b"""\
 </html>
 """
 
+
 class BaseTestCase(unittest.TestCase):
     def get_template(self, text):
         template = PageTemplate(text)
@@ -62,11 +63,12 @@ class BaseTestCase(unittest.TestCase):
 
     def assert_same(self, s1, s2):
         L1 = s1.splitlines()
-        L1 = list(filter(None, [ ' '.join(x.split()).strip() for x in L1 ]))
+        L1 = list(filter(None, [' '.join(x.split()).strip() for x in L1]))
         L2 = s2.splitlines()
-        L2 = list(filter(None, [ ' '.join(x.split()).strip() for x in L2 ]))
+        L2 = list(filter(None, [' '.join(x.split()).strip() for x in L2]))
         diff = '\n'.join(list(difflib.unified_diff(L1, L2)))
         assert diff == '', diff
+
 
 class XMLTestCase(BaseTestCase):
 
@@ -98,7 +100,7 @@ class XMLTestCase(BaseTestCase):
         """
         result = template(checked=True)
         self.assert_same(expected, result)
-        
+
     def test_bytes_checked_false(self):
         template = self.get_template_bytes()
         expected = """
@@ -118,7 +120,7 @@ class XMLTestCase(BaseTestCase):
         """
         result = template(checked=None)
         self.assert_same(expected, result)
-        
+
     def test_bytes_checked_default(self):
         template = self.get_template_bytes()
         expected = """
@@ -138,7 +140,7 @@ class XMLTestCase(BaseTestCase):
         """
         result = template(checked=True)
         self.assert_same(expected, result)
-        
+
     def test_str_checked_false(self):
         template = self.get_template_str()
         expected = """
@@ -158,7 +160,7 @@ class XMLTestCase(BaseTestCase):
         """
         result = template(checked=None)
         self.assert_same(expected, result)
-        
+
     def test_str_checked_default(self):
         template = self.get_template_str()
         expected = """
@@ -168,7 +170,8 @@ class XMLTestCase(BaseTestCase):
         """
         result = template(checked=template.default_marker.value)
         self.assert_same(expected, result)
-        
+
+
 class XMLWithEncodingTestCase(BaseTestCase):
 
     input_bytes = xml_w_enc_bytes
@@ -177,10 +180,11 @@ class XMLWithEncodingTestCase(BaseTestCase):
     def test_bytes_encoding(self):
         template = self.get_template_bytes()
         self.assertEqual(template.content_encoding, self.encoding)
-    
+
     def test_str_encoding(self):
         template = self.get_template_str()
         self.assertEqual(template.content_encoding, self.encoding)
+
 
 class HTML5TestCase(BaseTestCase):
 
@@ -220,7 +224,7 @@ class HTML5TestCase(BaseTestCase):
         """
         result = template(checked=True)
         self.assert_same(expected, result)
-        
+
     def test_bytes_checked_false(self):
         template = self.get_template_bytes()
         expected = """
@@ -258,7 +262,7 @@ class HTML5TestCase(BaseTestCase):
         """
         result = template(checked=None)
         self.assert_same(expected, result)
-        
+
     def test_bytes_checked_default(self):
         template = self.get_template_bytes()
         expected = """
@@ -296,7 +300,7 @@ class HTML5TestCase(BaseTestCase):
         """
         result = template(checked=True)
         self.assert_same(expected, result)
-        
+
     def test_str_checked_false(self):
         template = self.get_template_str()
         expected = """
@@ -334,7 +338,7 @@ class HTML5TestCase(BaseTestCase):
         """
         result = template(checked=None)
         self.assert_same(expected, result)
-        
+
     def test_str_checked_default(self):
         template = self.get_template_str()
         expected = """
@@ -354,6 +358,7 @@ class HTML5TestCase(BaseTestCase):
         result = template(checked=template.default_marker.value)
         self.assert_same(expected, result)
 
+
 class HTML5WithContentTypeAndEncodingTestCase(BaseTestCase):
 
     input_bytes = html5_w_ct_n_enc_bytes
@@ -361,11 +366,11 @@ class HTML5WithContentTypeAndEncodingTestCase(BaseTestCase):
     def test_bytes_content_type(self):
         template = self.get_template_bytes()
         self.assertEqual(template.content_type, 'foo/bar')
-    
+
     def test_bytes_encoding(self):
         template = self.get_template_bytes()
         self.assertEqual(template.content_encoding, 'utf-8')
-    
+
     def test_str_content_type(self):
         template = self.get_template_str()
         self.assertEqual(template.content_type, 'foo/bar')
@@ -373,4 +378,3 @@ class HTML5WithContentTypeAndEncodingTestCase(BaseTestCase):
     def test_str_encoding(self):
         template = self.get_template_str()
         self.assertEqual(template.content_encoding, 'utf-8')
-

--- a/src/chameleon/tests/test_bools_plus_sniffing.py
+++ b/src/chameleon/tests/test_bools_plus_sniffing.py
@@ -1,0 +1,392 @@
+import difflib
+import unittest
+
+from chameleon import PageTemplate
+
+boolean_html_attributes= [
+        # From http://www.w3.org/TR/xhtml1/#guidelines (C.10)
+        "compact",
+        "nowrap",
+        "ismap",
+        "declare",
+        "noshade",
+        "checked",
+        "disabled",
+        "readonly",
+        "multiple",
+        "selected",
+        "noresize",
+        "defer",
+    ]
+
+xml_bytes = b"""\
+<?xml version="1.0" ?>
+<input type="checkbox" checked="nope" tal:attributes="checked checked" />
+<input type="checkbox" checked="${checked}" />
+"""
+
+xml_w_enc_bytes = b"""\
+<?xml version="1.0" encoding="ascii" ?>
+<input type="checkbox" checked="nope" tal:attributes="checked checked" />
+<input type="checkbox" checked="${checked}" />
+"""
+
+html5_bytes = b"""\
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Title of document</title>
+</head>
+<body>
+  <form>
+    <input type="checkbox" checked="nope"
+           tal:attributes="checked checked" />
+    <input type="checkbox" checked="${checked}" />
+  </form>
+</body>
+</html>
+"""
+
+html5_w_ct_n_enc_bytes = b"""\
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="foo/bar; charset=utf-8" />
+  <title>Title of document</title>
+</head>
+<body>
+  <form>
+    <input type="checkbox" checked="nope"
+           tal:attributes="checked checked" />
+    <input type="checkbox" checked="${checked}" />
+  </form>
+</body>
+</html>
+"""
+
+class BaseTestCase(unittest.TestCase):
+    def get_template(self, text):
+        template = PageTemplate(
+            text,
+            boolean_attributes=boolean_html_attributes
+        )
+        return template
+
+    def get_template_bytes(self):
+        return self.get_template(self.input_bytes)
+
+    def get_template_str(self):
+        return self.get_template(self.input_bytes.decode('utf-8'))
+
+    def assert_same(self, s1, s2):
+        L1 = s1.splitlines()
+        L1 = list(filter(None, [ ' '.join(x.split()).strip() for x in L1 ]))
+        L2 = s2.splitlines()
+        L2 = list(filter(None, [ ' '.join(x.split()).strip() for x in L2 ]))
+        diff = '\n'.join(list(difflib.unified_diff(L1, L2)))
+        assert diff == '', diff
+
+class XMLTestCase(BaseTestCase):
+
+    input_bytes = xml_bytes
+
+    def test_bytes_content_type(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.content_type, 'text/xml')
+
+    def test_bytes_encoding(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.encoding, None)
+
+    def test_str_content_type(self):
+        template = self.get_template_str()
+        self.assertEqual(template.content_type, 'text/xml')
+
+    def test_str_encoding(self):
+        template = self.get_template_str()
+        self.assertEqual(template.encoding, None)
+
+    def test_bytes_checked_true(self):
+        template = self.get_template_bytes()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="True" />
+        <input type="checkbox" checked="True" />
+        """
+        result = template(checked=True)
+        self.assert_same(expected, result)
+        
+    def test_bytes_checked_false(self):
+        template = self.get_template_bytes()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="False" />
+        <input type="checkbox" checked="False" />
+        """
+        result = template(checked=False)
+        self.assert_same(expected, result)
+
+    def test_bytes_checked_None(self):
+        template = self.get_template_bytes()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" />
+        <input type="checkbox" />
+        """
+        result = template(checked=None)
+        self.assert_same(expected, result)
+        
+    def test_bytes_checked_default(self):
+        template = self.get_template_bytes()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="nope" />
+        <input type="checkbox" />
+        """
+        result = template(checked=template.default_marker)
+        self.assert_same(expected, result)
+
+    def test_str_checked_true(self):
+        template = self.get_template_str()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="True" />
+        <input type="checkbox" checked="True" />
+        """
+        result = template(checked=True)
+        self.assert_same(expected, result)
+        
+    def test_str_checked_false(self):
+        template = self.get_template_str()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="False" />
+        <input type="checkbox" checked="False" />
+        """
+        result = template(checked=False)
+        self.assert_same(expected, result)
+
+    def test_str_checked_None(self):
+        template = self.get_template_str()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" />
+        <input type="checkbox" />
+        """
+        result = template(checked=None)
+        self.assert_same(expected, result)
+        
+    def test_str_checked_default(self):
+        template = self.get_template_str()
+        expected = """
+        <?xml version="1.0" ?>
+        <input type="checkbox" checked="nope" />
+        <input type="checkbox" />
+        """
+        result = template(checked=template.default_marker)
+        self.assert_same(expected, result)
+        
+class XMLWithEncodingTestCase(BaseTestCase):
+
+    input_bytes = xml_w_enc_bytes
+
+    def test_bytes_encoding(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.encoding, 'ascii')
+    
+    def test_str_encoding(self):
+        template = self.get_template_str()
+        self.assertEqual(template.encoding, 'ascii')
+
+class HTML5TestCase(BaseTestCase):
+
+    input_bytes = html5_bytes
+
+    def test_bytes_content_type(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.content_type, None)
+
+    def test_bytes_encoding(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.encoding, None)
+
+    def test_str_content_type(self):
+        template = self.get_template_str()
+        self.assertEqual(template.content_type, None)
+
+    def test_str_encoding(self):
+        template = self.get_template_str()
+        self.assertEqual(template.encoding, None)
+
+    def test_bytes_checked_true(self):
+        template = self.get_template_bytes()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" checked="checked" />
+            <input type="checkbox" checked="checked" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=True)
+        self.assert_same(expected, result)
+        
+    def test_bytes_checked_false(self):
+        template = self.get_template_bytes()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" />
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=False)
+        self.assert_same(expected, result)
+
+    def test_bytes_checked_None(self):
+        template = self.get_template_bytes()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" />
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=None)
+        self.assert_same(expected, result)
+        
+    def test_bytes_checked_default(self):
+        template = self.get_template_bytes()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" checked="nope"/>
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=template.default_marker)
+        self.assert_same(expected, result)
+
+    def test_str_checked_true(self):
+        template = self.get_template_str()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" checked="checked" />
+            <input type="checkbox" checked="checked" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=True)
+        self.assert_same(expected, result)
+        
+    def test_str_checked_false(self):
+        template = self.get_template_str()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" />
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=False)
+        self.assert_same(expected, result)
+
+    def test_str_checked_None(self):
+        template = self.get_template_str()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" />
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=None)
+        self.assert_same(expected, result)
+        
+    def test_str_checked_default(self):
+        template = self.get_template_str()
+        expected = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Title of document</title>
+        </head>
+        <body>
+          <form>
+            <input type="checkbox" checked="nope" />
+            <input type="checkbox" />
+          </form>
+        </body>
+        </html>
+        """
+        result = template(checked=template.default_marker)
+        self.assert_same(expected, result)
+
+class HTML5WithContentTypeAndEncodingTestCase(BaseTestCase):
+
+    input_bytes = html5_w_ct_n_enc_bytes
+
+    def test_bytes_content_type(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.encoding, 'foo/bar')
+    
+    def test_bytes_encoding(self):
+        template = self.get_template_bytes()
+        self.assertEqual(template.encoding, 'utf-8')
+    
+    def test_str_content_type(self):
+        template = self.get_template_str()
+        self.assertEqual(template.encoding, 'foo/bar')
+
+    def test_str_encoding(self):
+        template = self.get_template_str()
+        self.assertEqual(template.encoding, 'utf-8')
+

--- a/src/chameleon/tests/test_bools_plus_sniffing.py
+++ b/src/chameleon/tests/test_bools_plus_sniffing.py
@@ -3,6 +3,7 @@ import unittest
 
 from chameleon import PageTemplate
 
+
 xml_bytes = b"""\
 <?xml version="1.0" ?>
 <input type="checkbox" checked="nope" tal:attributes="checked checked" />

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -576,7 +576,7 @@ class ZopePageTemplatesTest(RenderTestCase):
                 '<input type="input" tal:attributes="checked default" />',
                 '<input type="input" tal:attributes="dynamic_true" />',
                 '<input type="input" tal:attributes="dynamic_false" />',
-                '<input type="input" tal:attributes="checked dynamic_marker" />',
+                '<input type="input" tal:attributes="checked dynamic_marker" />',  # noqa: E501 line too long
                 '<input type="input" checked="${dynamic_marker}" />',
                 '<input type="input" checked="${True}" />',
                 '<input type="input" checked="${False}" />',

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -576,6 +576,8 @@ class ZopePageTemplatesTest(RenderTestCase):
                 '<input type="input" tal:attributes="checked default" />',
                 '<input type="input" tal:attributes="dynamic_true" />',
                 '<input type="input" tal:attributes="dynamic_false" />',
+                '<input type="input" tal:attributes="checked dynamic_marker" />',
+                '<input type="input" checked="${dynamic_marker}" />',
                 '<input type="input" checked="${True}" />',
                 '<input type="input" checked="${False}" />',
                 '<input type="input" checked="${[]}" />',
@@ -583,11 +585,11 @@ class ZopePageTemplatesTest(RenderTestCase):
 
             ))
         )
-
         self.assertEqual(
             template(
                 dynamic_true={"checked": True},
-                dynamic_false={"checked": False}
+                dynamic_false={"checked": False},
+                dynamic_marker=template.default_marker.value,
             ),
             "\n".join((
                 '<input type="input" />',
@@ -596,6 +598,8 @@ class ZopePageTemplatesTest(RenderTestCase):
                 '<input type="input" />',
                 '<input type="input" />',
                 '<input type="input" checked="checked" />',
+                '<input type="input" />',
+                '<input type="input" />',
                 '<input type="input" />',
                 '<input type="input" checked="checked" />',
                 '<input type="input" />',

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -580,9 +580,9 @@ class ZopePageTemplatesTest(RenderTestCase):
                 '<input type="input" checked="${False}" />',
                 '<input type="input" checked="${[]}" />',
                 '<input type="input" checked="checked" tal:attributes="checked default" />',  # noqa: E501 line too long
-            )),
-            boolean_attributes={
-                'checked'})
+
+            ))
+        )
 
         self.assertEqual(
             template(
@@ -659,7 +659,7 @@ class ZopePageTemplatesTest(RenderTestCase):
                                     '      class="foo"\r\n'
                                     '      tal:content="string:bar"/>')
         self.assertEqual(template(),
-                         '<span id="span_id"\r\n'
+                         '<span id="span_id"\n'
                          '      class="foo">bar</span>')
 
     def test_digest(self):

--- a/src/chameleon/utils.py
+++ b/src/chameleon/utils.py
@@ -85,7 +85,6 @@ def read_bytes(body, default_encoding):
 
     if body.startswith(_xml_decl):
         content_type = "text/xml"
-
         encoding = read_xml_encoding(body) or default_encoding
     else:
         content_type, encoding = detect_encoding(body, default_encoding)


### PR DESCRIPTION
Boolean attributes are now automatically configured for templates in non-XML mode, presuming that we're being used to generate HTML.

This means that the same loading mechanism can be used for both XML and HTML-based templates.

The list of attributes is defined in `chameleon.zpt.template`:
```python
BOOLEAN_HTML_ATTRIBUTES = [
    # From http://www.w3.org/TR/xhtml1/#guidelines (C.10)
    "compact",
    "nowrap",
    "ismap",
    "declare",
    "noshade",
    "checked",
    "disabled",
    "readonly",
    "multiple",
    "selected",
    "noresize",
    "defer",
]
```
See #385 for more context.