### PR TITLE
Refactor package tests

### DIFF
--- a/src/chameleon/tests/test_loader.py
+++ b/src/chameleon/tests/test_loader.py
@@ -1,4 +1,14 @@
+import os
+import sys
+import tempfile
+import textwrap
 import unittest
+import zipimport
+from contextlib import contextmanager
+from pathlib import Path
+
+from setuptools import find_packages
+from setuptools import setup
 
 
 class LoadTests:
@@ -46,83 +56,11 @@ class LoadTests:
         self.assertEqual(result.spec.filename, abs)
 
     def test_load_egg(self):
-        import subprocess
-        import sys
-        import tempfile
-        import textwrap
-        import zipimport
-        from pathlib import Path
-        with tempfile.TemporaryDirectory() as tmpdir:
-            basedir = Path(tmpdir) / 'chameleon_test_pkg'
-            pkgdir = basedir / 'src' / 'chameleon_test_pkg'
-            templatesdir = pkgdir / 'templates'
-            templatesdir.mkdir(parents=True)
-            with basedir.joinpath('MANIFEST.in').open('w') as f:
-                f.write('recursive-include src *.pt')
-            with basedir.joinpath('setup.py').open('w') as f:
-                f.write(textwrap.dedent("""
-                    from setuptools import find_packages
-                    from setuptools import setup
-
-
-                    setup(
-                        name="chameleon-test-pkg",
-                        version="1.0",
-                        packages=find_packages('src'),
-                        package_dir={'': 'src'},
-                        include_package_data=True)
-                """))
-            pkgdir.joinpath('__init__.py').touch()
-            with templatesdir.joinpath('test.pt').open('w') as f:
-                f.write(textwrap.dedent("""
-                    <html>
-                    <head><title>Test Title</title></head>
-                    <body>${content}</body>
-                    </html>
-                """))
-            try:
-                subprocess.check_output(
-                    ['python', 'setup.py', 'bdist_egg'],
-                    cwd=basedir,
-                    stderr=subprocess.STDOUT)
-            except subprocess.CalledProcessError as e:
-                print('\n', e.output.decode(), file=sys.stderr)
-                raise
-            (egg_path,) = basedir.glob('dist/*.egg')
-            zipimport.zipimporter(
-                str(egg_path)).load_module('chameleon_test_pkg')
-            try:
-                # we use auto_reload to trigger a call of mtime
-                loader = self._makeOne(auto_reload=True)
-                result = self._load(
-                    loader, 'chameleon_test_pkg:templates/test.pt')
-                self.assertIsNone(result._v_last_read)
-                output = result(content='Test Content')
-                self.assertIsNotNone(result._v_last_read)
-                old_v_last_read = result._v_last_read
-                self.assertIn("Test Title", output)
-                self.assertIn("Test Content", output)
-                # make sure the template isn't recooked
-                output = result(content='foo')
-                self.assertEqual(result._v_last_read, old_v_last_read)
-            finally:
-                # cleanup
-                sys.modules.pop('chameleon_test_pkg', None)
+        with self._test_load_package("bdist_egg", ".egg"):
+            pass
 
     def test_load_wheel(self):
-        import subprocess
-        import sys
-        import tempfile
-        import textwrap
-        import zipimport
-        from pathlib import Path
-        with tempfile.TemporaryDirectory() as tmpdir:
-            basedir = Path(tmpdir) / 'chameleon_test_pkg'
-            pkgdir = basedir / 'src' / 'chameleon_test_pkg'
-            templatesdir = pkgdir / 'templates'
-            templatesdir.mkdir(parents=True)
-            with basedir.joinpath('MANIFEST.in').open('w') as f:
-                f.write('recursive-include src *.pt')
+        with self._test_load_package("bdist_wheel", ".whl") as basedir:
             with basedir.joinpath('pyproject.toml').open('w') as f:
                 f.write(textwrap.dedent("""
                     [build-system]
@@ -139,38 +77,56 @@ class LoadTests:
                     [tool.setuptools.packages.find]
                     where = ["src"]
                 """))
-            pkgdir.joinpath('__init__.py').touch()
-            with templatesdir.joinpath('test.pt').open('w') as f:
-                f.write(textwrap.dedent("""
-                    <html>
-                    <head><title>Test Title</title></head>
-                    <body>${content}</body>
-                    </html>
-                """))
+
+    @contextmanager
+    def _test_load_package(self, command, pkg_extension):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            basedir = Path(tmpdir) / 'chameleon_test_pkg'
+            pkgdir = basedir / 'src' / 'chameleon_test_pkg'
+            templatesdir = pkgdir / 'templates'
+            templatesdir.mkdir(parents=True)
+
+            olddir = os.getcwd()
+            os.chdir(basedir)
+
             try:
-                subprocess.check_output(
-                    ['python', '-m', 'build', '--no-isolation', '--wheel'],
-                    cwd=basedir,
-                    stderr=subprocess.STDOUT)
-            except subprocess.CalledProcessError as e:
-                print('\n', e.output.decode(), file=sys.stderr)
-                raise
-            (wheel_path,) = basedir.glob('dist/*.whl')
+                with open('MANIFEST.in', 'w') as f:
+                    f.write('recursive-include src *.pt')
+
+                yield basedir
+
+                pkgdir.joinpath('__init__.py').touch()
+                with templatesdir.joinpath('test.pt').open('w') as f:
+                    f.write("<html><body>${content}</body></html>")
+
+                setup(
+                    name="chameleon-test-pkg",
+                    version="1.0",
+                    packages=find_packages('src'),
+                    package_dir={'': 'src'},
+                    include_package_data=True,
+                    script_args=[command],
+                )
+            finally:
+                os.chdir(olddir)
+
+            (package_path,) = basedir.glob('dist/*' + pkg_extension)
+
             zipimport.zipimporter(
-                str(wheel_path)).load_module('chameleon_test_pkg')
+                str(package_path)).load_module('chameleon_test_pkg')
+
             try:
                 # we use auto_reload to trigger a call of mtime
                 loader = self._makeOne(auto_reload=True)
                 result = self._load(
                     loader, 'chameleon_test_pkg:templates/test.pt')
                 self.assertIsNone(result._v_last_read)
-                output = result(content='Test Content')
+                output = result(content='foo')
                 self.assertIsNotNone(result._v_last_read)
                 old_v_last_read = result._v_last_read
-                self.assertIn("Test Title", output)
-                self.assertIn("Test Content", output)
+                self.assertIn("foo", output)
                 # make sure the template isn't recooked
-                output = result(content='foo')
+                output = result(content='bar')
                 self.assertEqual(result._v_last_read, old_v_last_read)
             finally:
                 # cleanup

--- a/src/chameleon/tests/test_loader.py
+++ b/src/chameleon/tests/test_loader.py
@@ -1,10 +1,8 @@
 import os
 import sys
 import tempfile
-import textwrap
 import unittest
 import zipimport
-from contextlib import contextmanager
 from pathlib import Path
 
 from setuptools import find_packages
@@ -56,29 +54,11 @@ class LoadTests:
         self.assertEqual(result.spec.filename, abs)
 
     def test_load_egg(self):
-        with self._test_load_package("bdist_egg", ".egg"):
-            pass
+        self._test_load_package("bdist_egg", ".egg")
 
     def test_load_wheel(self):
-        with self._test_load_package("bdist_wheel", ".whl") as basedir:
-            with basedir.joinpath('pyproject.toml').open('w') as f:
-                f.write(textwrap.dedent("""
-                    [build-system]
-                    requires = ["setuptools"]
-                    build-backend = "setuptools.build_meta"
+        self._test_load_package("bdist_wheel", ".whl")
 
-                    [project]
-                    name = "chameleon-test-pkg"
-                    version = "1.0"
-
-                    [tool.setuptools]
-                    include-package-data = true
-
-                    [tool.setuptools.packages.find]
-                    where = ["src"]
-                """))
-
-    @contextmanager
     def _test_load_package(self, command, pkg_extension):
         with tempfile.TemporaryDirectory() as tmpdir:
             basedir = Path(tmpdir) / 'chameleon_test_pkg'
@@ -92,8 +72,6 @@ class LoadTests:
             try:
                 with open('MANIFEST.in', 'w') as f:
                     f.write('recursive-include src *.pt')
-
-                yield basedir
 
                 pkgdir.joinpath('__init__.py').touch()
                 with templatesdir.joinpath('test.pt').open('w') as f:


### PR DESCRIPTION
Previously, the testing code relied on calling out to an external process, which is both a little annoying but also broke systems where `python` was not present – for example, on my system only `python3` was.