### PR TITLE
Treat (translation) target language like domain and context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Changes
 
 In next release ...
 
+- Implicit translation now provides the translation context, domain,
+  and target language to the translation function (if applicable). Previously,
+  the target language was provided, but this did not respect a change via
+  `i18n:target`.
+  (`#369 <https://github.com/malthe/chameleon/issues/369>`_)
 
 - Replace ``pkg_resources`` with newer and faster ``importlib.resources`` and
   ``importlib.metadata``. Just importing ``pkg_resources`` becomes slower and

--- a/src/chameleon/nodes.py
+++ b/src/chameleon/nodes.py
@@ -238,6 +238,12 @@ class Domain(Node):
     _fields = "name", "node"
 
 
+class Target(Node):
+    """Update translation target."""
+
+    _fields = "expression", "node"
+
+
 class TxContext(Node):
     """Update translation context."""
 

--- a/src/chameleon/template.py
+++ b/src/chameleon/template.py
@@ -199,8 +199,14 @@ class BaseTemplate:
         rcontext = {}
         self.cook_check()
         stream = self.output_stream_factory()
+        target_language = __kw.get("target_language")
         try:
-            self._render(stream, econtext, rcontext)
+            self._render(
+                stream,
+                econtext,
+                rcontext,
+                target_language=target_language
+            )
         except RecursionError:
             raise
         except BaseException:

--- a/src/chameleon/tests/inputs/079-implicit-i18n.pt
+++ b/src/chameleon/tests/inputs/079-implicit-i18n.pt
@@ -12,5 +12,8 @@
       <br />
       bar.
     </div>
+    <div tal:define="Message import:chameleon.tests.test_templates.Message" i18n:target="string:fr">
+      ${Message()}
+    </div>
   </body>
 </html>

--- a/src/chameleon/tests/inputs/124-translation-target.pt
+++ b/src/chameleon/tests/inputs/124-translation-target.pt
@@ -2,5 +2,6 @@
   <body>
     <h1 i18n:translate="" i18n:target="string:fr">Hello world!</h1>
     <p i18n:translate="" i18n:target="default">It's a big world.</p>
+    <p>${target_language}</p>
   </body>
 </html>

--- a/src/chameleon/tests/outputs/079-en.pt
+++ b/src/chameleon/tests/outputs/079-en.pt
@@ -12,5 +12,8 @@
       <br />
       bar. ('bar.' translation into 'en')
     </div>
+    <div>
+      Message ('message' translation into 'fr')
+    </div>
   </body>
 </html>

--- a/src/chameleon/tests/outputs/079.pt
+++ b/src/chameleon/tests/outputs/079.pt
@@ -12,5 +12,8 @@
       <br />
       bar.
     </div>
+    <div>
+      Message ('message' translation into 'fr')
+    </div>
   </body>
 </html>

--- a/src/chameleon/tests/outputs/124-en.pt
+++ b/src/chameleon/tests/outputs/124-en.pt
@@ -2,5 +2,6 @@
   <body>
     <h1>Hello world! ('Hello world!' translation into 'fr')</h1>
     <p>It's a big world. ('It's a big world.' translation into 'en')</p>
+    <p>en</p>
   </body>
 </html>

--- a/src/chameleon/tests/outputs/124.pt
+++ b/src/chameleon/tests/outputs/124.pt
@@ -2,5 +2,6 @@
   <body>
     <h1>Hello world! ('Hello world!' translation into 'fr')</h1>
     <p>It's a big world.</p>
+    <p></p>
   </body>
 </html>

--- a/src/chameleon/tests/test_templates.py
+++ b/src/chameleon/tests/test_templates.py
@@ -496,7 +496,7 @@ class ZopePageTemplatesTest(RenderTestCase):
             def __init__(self, *args, **kwargs):
                 calls.append((args, kwargs))
 
-        def _render(stream, econtext, rcontext):
+        def _render(stream, econtext, rcontext, **kw):
             exc = TestException('foo', bar='baz')
             rcontext['__error__'] = ('expression', 1, 42, 'test.pt', exc),
             raise exc

--- a/src/chameleon/zpt/program.py
+++ b/src/chameleon/zpt/program.py
@@ -395,22 +395,6 @@ class MacroProgram(ElementProgram):
             if defines is None:
                 raise ParseError("Invalid define syntax.", clause)
 
-        # i18n:target
-        try:
-            target_language = ns[I18N, 'target']
-        except KeyError:
-            pass
-        else:
-            # The name "default" is an alias for the target language
-            # variable. We simply replace it.
-            target_language = target_language.replace(
-                'default', 'target_language'
-            )
-
-            defines.append(
-                ('local', ("target_language", ), target_language)
-            )
-
         assignments = [
             nodes.Assignment(
                 names, nodes.Value(expr), context == "local")
@@ -509,6 +493,17 @@ class MacroProgram(ElementProgram):
         else:
             CONTEXT = partial(nodes.TxContext, clause)
 
+        # i18n:target
+        try:
+            clause = ns[I18N, 'target']
+        except KeyError:
+            TARGET = skip
+        else:
+            TARGET = lambda node: nodes.Define(  # noqa:  E731 do not assign a lambda expression, use a def
+                [nodes.Alias(["default"], "target_language")],
+                nodes.Target(clause, node)
+            )
+
         # i18n:name
         try:
             clause = ns[I18N, 'name']
@@ -532,6 +527,7 @@ class MacroProgram(ElementProgram):
             SWITCH,
             DOMAIN,
             CONTEXT,
+            TARGET,
         )
 
         # metal:fill-slot

--- a/src/chameleon/zpt/template.py
+++ b/src/chameleon/zpt/template.py
@@ -314,15 +314,11 @@ class PageTemplate(BaseTemplate):
         else:
             decode = bytes.decode
 
-        target_language = _kw.get('target_language')
-
         setdefault = _kw.setdefault
         setdefault("__translate", translate)
-        setdefault("__convert",
-                   partial(translate, target_language=target_language))
         setdefault("__decode", decode)
-        setdefault("target_language", None)
         setdefault("__on_error_handler", self.on_error_handler)
+        setdefault("target_language", None)
 
         # Make sure we have a repeat dictionary
         if 'repeat' not in _kw:


### PR DESCRIPTION
Provide translation domain, context and target language when doing implicit conversion.

Note that 'target_language' is no longer defined as a variable, but as internal state (and disallowed as a variable name) – similar to domain and context.

This fixes issue #369.