### PR TITLE
Fix names of dependencies.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+In next release ...
+
+- Fix names of dependencies for ``importlib_resources`` and
+  ``importlib_metadata``.
+  (``#394 <https://github.com/malthe/chameleon/pull/394>`_)
+
+
 4.3.0 (2023-12-04)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ except BaseException:  # doesn't work under tox/pip
     CHANGES = ''
 
 install_requires = [
-    'importlib.metadata;python_version<"3.10"',
-    'importlib.resources;python_version<"3.9"']
+    'importlib-metadata;python_version<"3.10"',
+    'importlib-resources;python_version<"3.9"']
 
 
 class Benchmark(test):


### PR DESCRIPTION
The dependencies have been named ``importlib.resources`` and ``importlib.metadata`` - with dots, making them look like module names.  This caused ``ContextualVersionConflict``s in some setups (see below). Replacing the names by an underscore, like the name of the packages at PyPI have, solved this problem.

This happend when running in under ``tox -e py37`` where the actual test command is ``python setup.py test``:
```
pkg_resources.ContextualVersionConflict:
(importlib-resources 5.12.0 (…/myproj/.eggs/importlib_resources-5.12.0-py3.7.egg),
Requirement.parse('importlib.resources; python_version < "3.9"'), {'chameleon'})
```