### PR TITLE
Adds type hints to public API.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,6 @@ jobs:
         config:
         # [Python version, tox env]
         - ["3.9",   "lint"]
-        - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
         - ["3.11",  "py311"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
         - ["pypy-3.9", "pypy3"]
         - ["3.9",   "docs"]
         - ["3.9",   "coverage"]
+        - ["3.12",   "mypy"]
 
     runs-on: ${{ matrix.os[1] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .eggs/
 .installed.cfg
 .mr.developer.cfg
+.mypy_cache/
 .tox/
 .vscode/
 __pycache__/

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Chameleon is an HTML/XML template engine for `Python
 <http://www.python.org>`_. It uses the *page templates* language.
 
 You can use it in any Python application with just about any
-version of Python (3.8+ and up, plus `pypy 3
+version of Python (3.9+ and up, plus `pypy 3
 <http://pypy.org>`_).
 
 Visit the `documentation <https://chameleon.readthedocs.io/en/latest/>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ exclude = "/tests/"
 follow_imports = "silent"
 
 [[tool.mypy.overrides]]
-# strict config for public API
+# strict config for fully typed modules and public API
 module = [
-    "chameleon.exc.RenderError",
-    "chameleon.exc.TemplateError",
+    "chameleon.exc.*",
+    "chameleon.utils.*",
     "chameleon.zpt.loader.*",
     "chameleon.zpt.template.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
+# we may want to include tests eventually
+exclude = "/tests/"
+follow_imports = "silent"
+
+[[tool.mypy.overrides]]
+# strict config for public API
+module = [
+    "chameleon.exc.RenderError",
+    "chameleon.exc.TemplateError",
+    "chameleon.zpt.loader.*",
+    "chameleon.zpt.template.*",
+]
+disallow_any_unimported = true
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_decorators = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = ["zope.*"]
+ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,10 @@ ignore =
 [isort]
 force_single_line = True
 combine_as_imports = True
-sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
-known_third_party = six, docutils, pkg_resources, pytz
-known_zope =
-known_first_party =
-default_section = ZOPE
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+known_first_party = chameleon
+extra_standard_library = _typeshed, typing_extensions
+default_section = THIRDPARTY
 line_length = 79
 lines_after_imports = 2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ universal = 0
 
 [flake8]
 doctests = 1
+extend-select = TC1
 # F401 imported but unused
 per-file-ignores =
     src/chameleon/__init__.py: F401

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,7 @@ except BaseException:  # doesn't work under tox/pip
     README = ''
     CHANGES = ''
 
-install_requires = [
-    'importlib-metadata;python_version<"3.10"',
-    'importlib-resources;python_version<"3.9"']
+install_requires = ['importlib-metadata;python_version<"3.10"']
 
 
 class Benchmark(test):
@@ -49,7 +47,6 @@ setup(
         "Intended Audience :: Developers",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -69,7 +66,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=install_requires,
     extras_require={
         'docs': {

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,11 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,
+    package_data={
+        'chameleon': [
+            'py.typed',
+        ],
+    },
     python_requires='>=3.9',
     install_requires=install_requires,
     extras_require={

--- a/src/chameleon/astutil.py
+++ b/src/chameleon/astutil.py
@@ -15,15 +15,20 @@
 import ast
 import collections
 import logging
+import typing as t
 import weakref
 
 
+_F = t.TypeVar('_F', bound=t.Callable[..., t.Any])
+_AnyNode = t.Union['Node', ast.AST]
+
 AST_NONE = ast.Name(id='None', ctx=ast.Load())
 
+node_annotations: t.MutableMapping['_AnyNode', '_AnyNode']
 node_annotations = weakref.WeakKeyDictionary()
 
 try:
-    node_annotations[ast.Name()] = None
+    node_annotations[ast.Name()] = None  # type: ignore[assignment]
 except TypeError:
     logging.debug(
         "Unable to create weak references to AST nodes. "
@@ -115,17 +120,19 @@ def walk(node):
         yield node
 
 
-def copy(source, target):
+def copy(source, target) -> None:
     target.__class__ = source.__class__
     target.__dict__ = source.__dict__
 
 
-def swap(body, replacement, name):
+def swap(body, replacement, name) -> None:
     root = ast.Expression(body=body)
     for node in ast.walk(root):
-        if (isinstance(node, ast.Name) and
-            isinstance(node.ctx, ast.Load) and
-                node.id == name):
+        if (
+            isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Load)
+            and node.id == name
+        ):
             assert hasattr(replacement, '_fields')
             node_annotations.setdefault(node, replacement)
 
@@ -138,23 +145,25 @@ class Node:
     """AST baseclass that gives us a convenient initialization
     method. We explicitly declare and use the ``_fields`` attribute."""
 
-    _fields = ()
+    _fields: t.ClassVar[t.Tuple[str, ...]] = ()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         assert isinstance(self._fields, tuple)
         self.__dict__.update(kwargs)
         for name, value in zip(self._fields, args):
             setattr(self, name, value)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Poor man's single-line pretty printer."""
 
         name = type(self).__name__
         return '<{}{} at {:x}>'.format(
             name,
-            "".join(" {}={!r}".format(name, getattr(self, name, "\"?\""))
-                    for name in self._fields),
-            id(self)
+            "".join(
+                " {}={!r}".format(name, getattr(self, name, "\"?\""))
+                for name in self._fields
+            ),
+            id(self),
         )
 
     def extract(self, condition):
@@ -206,6 +215,10 @@ class TokenRef(Node):
     _fields = "pos", "length"
 
 
+_Position = t.Tuple[int, int]
+_LineInfo = t.List[t.Tuple[int, t.Optional[_Position]]]
+
+
 class ASTCodeGenerator:
     """General purpose base class for AST transformations.
 
@@ -231,14 +244,13 @@ class ASTCodeGenerator:
 
         # strip trivial lines
         self.code = "\n".join(
-            line.strip() and line or ""
-            for line in self.lines
+            line.strip() and line or "" for line in self.lines
         )
 
-    def _change_indent(self, delta):
+    def _change_indent(self, delta) -> None:
         self.indent += delta
 
-    def _new_line(self):
+    def _new_line(self) -> None:
         if self.line is not None:
             self.lines.append(self.line)
             self.lines_info.append(self.line_info)
@@ -247,10 +259,15 @@ class ASTCodeGenerator:
             self.line_info = []
             self.last = None
         else:
-            self.line_info = [(0, self.blame_stack[-1],)]
+            self.line_info = [
+                (
+                    0,
+                    self.blame_stack[-1],
+                )
+            ]
             self.last = self.blame_stack[-1]
 
-    def _write(self, s):
+    def _write(self, s) -> None:
         if len(s) == 0:
             return
         if len(self.blame_stack) == 0:
@@ -263,7 +280,7 @@ class ASTCodeGenerator:
                 self.line_info.append((len(self.line), self.last))
         self.line += s
 
-    def flush(self):
+    def flush(self) -> None:
         if self.line:
             self._new_line()
 
@@ -273,22 +290,31 @@ class ASTCodeGenerator:
         if isinstance(node, tuple):
             return tuple([self.visit(n) for n in node])
         try:
-            self.blame_stack.append((node.lineno, node.col_offset,))
+            self.blame_stack.append(
+                (
+                    node.lineno,
+                    node.col_offset,
+                )
+            )
             info = True
         except AttributeError:
             info = False
         visitor = getattr(self, 'visit_%s' % node.__class__.__name__, None)
         if visitor is None:
-            raise Exception('No handler for ``{}`` ({}).'.format(
-                node.__class__.__name__, repr(node)))
+            raise Exception(
+                'No handler for ``{}`` ({}).'.format(
+                    node.__class__.__name__, repr(node)
+                )
+            )
         ret = visitor(node)
         if info:
             self.blame_stack.pop()
         return ret
 
-    def visit_Module(self, node):
+    def visit_Module(self, node) -> None:
         for n in node.body:
             self.visit(n)
+
     visit_Interactive = visit_Module
     visit_Suite = visit_Module
 
@@ -297,7 +323,7 @@ class ASTCodeGenerator:
 
     # arguments = (expr* args, identifier? vararg,
     #              identifier? kwarg, expr* defaults)
-    def visit_arguments(self, node):
+    def visit_arguments(self, node) -> None:
         first = True
         no_default_count = len(node.args) - len(node.defaults)
         for i, arg in enumerate(node.args):
@@ -322,12 +348,12 @@ class ASTCodeGenerator:
                 first = False
             self._write('**' + node.kwarg)
 
-    def visit_arg(self, node):
+    def visit_arg(self, node) -> None:
         self._write(node.arg)
 
     # FunctionDef(identifier name, arguments args,
     #                           stmt* body, expr* decorators)
-    def visit_FunctionDef(self, node):
+    def visit_FunctionDef(self, node) -> None:
         self._new_line()
         for decorator in getattr(node, 'decorator_list', ()):
             self._new_line()
@@ -343,7 +369,7 @@ class ASTCodeGenerator:
         self._change_indent(-1)
 
     # ClassDef(identifier name, expr* bases, stmt* body)
-    def visit_ClassDef(self, node):
+    def visit_ClassDef(self, node) -> None:
         self._new_line()
         self._write('class ' + node.name)
         if node.bases:
@@ -360,7 +386,7 @@ class ASTCodeGenerator:
         self._change_indent(-1)
 
     # Return(expr? value)
-    def visit_Return(self, node):
+    def visit_Return(self, node) -> None:
         self._new_line()
         self._write('return')
         if getattr(node, 'value', None):
@@ -368,7 +394,7 @@ class ASTCodeGenerator:
             self.visit(node.value)
 
     # Delete(expr* targets)
-    def visit_Delete(self, node):
+    def visit_Delete(self, node) -> None:
         self._new_line()
         self._write('del ')
         self.visit(node.targets[0])
@@ -377,7 +403,7 @@ class ASTCodeGenerator:
             self.visit(target)
 
     # Assign(expr* targets, expr value)
-    def visit_Assign(self, node):
+    def visit_Assign(self, node) -> None:
         self._new_line()
         for target in node.targets:
             self.visit(target)
@@ -385,14 +411,14 @@ class ASTCodeGenerator:
         self.visit(node.value)
 
     # AugAssign(expr target, operator op, expr value)
-    def visit_AugAssign(self, node):
+    def visit_AugAssign(self, node) -> None:
         self._new_line()
         self.visit(node.target)
         self._write(' ' + self.binary_operators[node.op.__class__] + '= ')
         self.visit(node.value)
 
     # JoinedStr(expr* values)
-    def visit_JoinedStr(self, node):
+    def visit_JoinedStr(self, node) -> None:
         if node.values:
             self._write('"".join((')
             for value in node.values:
@@ -403,7 +429,7 @@ class ASTCodeGenerator:
             self._write('""')
 
     # FormattedValue(expr value)
-    def visit_FormattedValue(self, node):
+    def visit_FormattedValue(self, node) -> None:
         if node.conversion == ord('r'):
             self._write('repr')
         elif node.conversion == ord('a'):
@@ -419,7 +445,7 @@ class ASTCodeGenerator:
         self._write(')')
 
     # Print(expr? dest, expr* values, bool nl)
-    def visit_Print(self, node):
+    def visit_Print(self, node) -> None:
         self._new_line()
         self._write('print')
         if getattr(node, 'dest', None):
@@ -438,7 +464,7 @@ class ASTCodeGenerator:
             self._write(',')
 
     # For(expr target, expr iter, stmt* body, stmt* orelse)
-    def visit_For(self, node):
+    def visit_For(self, node) -> None:
         self._new_line()
         self._write('for ')
         self.visit(node.target)
@@ -458,7 +484,7 @@ class ASTCodeGenerator:
             self._change_indent(-1)
 
     # While(expr test, stmt* body, stmt* orelse)
-    def visit_While(self, node):
+    def visit_While(self, node) -> None:
         self._new_line()
         self._write('while ')
         self.visit(node.test)
@@ -476,7 +502,7 @@ class ASTCodeGenerator:
             self._change_indent(-1)
 
     # If(expr test, stmt* body, stmt* orelse)
-    def visit_If(self, node):
+    def visit_If(self, node) -> None:
         self._new_line()
         self._write('if ')
         self.visit(node.test)
@@ -494,7 +520,7 @@ class ASTCodeGenerator:
             self._change_indent(-1)
 
     # With(expr context_expr, expr? optional_vars, stmt* body)
-    def visit_With(self, node):
+    def visit_With(self, node) -> None:
         self._new_line()
         self._write('with ')
         self.visit(node.context_expr)
@@ -529,7 +555,7 @@ class ASTCodeGenerator:
         self.visit(node.tback)
 
     # Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
-    def visit_Try(self, node):
+    def visit_Try(self, node) -> None:
         self._new_line()
         self._write('try:')
         self._change_indent(1)
@@ -557,7 +583,7 @@ class ASTCodeGenerator:
             self._change_indent(-1)
 
     # TryExcept(stmt* body, excepthandler* handlers, stmt* orelse)
-    def visit_TryExcept(self, node):
+    def visit_TryExcept(self, node) -> None:
         self._new_line()
         self._write('try:')
         self._change_indent(1)
@@ -576,7 +602,7 @@ class ASTCodeGenerator:
             self._change_indent(-1)
 
     # excepthandler = (expr? type, expr? name, stmt* body)
-    def visit_ExceptHandler(self, node):
+    def visit_ExceptHandler(self, node) -> None:
         self._new_line()
         self._write('except')
         if getattr(node, 'type', None):
@@ -590,10 +616,11 @@ class ASTCodeGenerator:
         for statement in node.body:
             self.visit(statement)
         self._change_indent(-1)
+
     visit_excepthandler = visit_ExceptHandler
 
     # TryFinally(stmt* body, stmt* finalbody)
-    def visit_TryFinally(self, node):
+    def visit_TryFinally(self, node) -> None:
         self._new_line()
         self._write('try:')
         self._change_indent(1)
@@ -610,7 +637,7 @@ class ASTCodeGenerator:
             self._change_indent(-1)
 
     # Assert(expr test, expr? msg)
-    def visit_Assert(self, node):
+    def visit_Assert(self, node) -> None:
         self._new_line()
         self._write('assert ')
         self.visit(node.test)
@@ -618,14 +645,14 @@ class ASTCodeGenerator:
             self._write(', ')
             self.visit(node.msg)
 
-    def visit_alias(self, node):
+    def visit_alias(self, node) -> None:
         self._write(node.name)
         if getattr(node, 'asname', None):
             self._write(' as ')
             self._write(node.asname)
 
     # Import(alias* names)
-    def visit_Import(self, node):
+    def visit_Import(self, node) -> None:
         self._new_line()
         self._write('import ')
         self.visit(node.names[0])
@@ -634,7 +661,7 @@ class ASTCodeGenerator:
             self.visit(name)
 
     # ImportFrom(identifier module, alias* names, int? level)
-    def visit_ImportFrom(self, node):
+    def visit_ImportFrom(self, node) -> None:
         self._new_line()
         self._write('from ')
         if node.level:
@@ -647,7 +674,7 @@ class ASTCodeGenerator:
             self.visit(name)
 
     # Exec(expr body, expr? globals, expr? locals)
-    def visit_Exec(self, node):
+    def visit_Exec(self, node) -> None:
         self._new_line()
         self._write('exec ')
         self.visit(node.body)
@@ -661,7 +688,7 @@ class ASTCodeGenerator:
         self.visit(node.locals)
 
     # Global(identifier* names)
-    def visit_Global(self, node):
+    def visit_Global(self, node) -> None:
         self._new_line()
         self._write('global ')
         self.visit(node.names[0])
@@ -670,38 +697,39 @@ class ASTCodeGenerator:
             self.visit(name)
 
     # Expr(expr value)
-    def visit_Expr(self, node):
+    def visit_Expr(self, node) -> None:
         self._new_line()
         self.visit(node.value)
 
     # Pass
-    def visit_Pass(self, node):
+    def visit_Pass(self, node) -> None:
         self._new_line()
         self._write('pass')
 
     # Break
-    def visit_Break(self, node):
+    def visit_Break(self, node) -> None:
         self._new_line()
         self._write('break')
 
     # Continue
-    def visit_Continue(self, node):
+    def visit_Continue(self, node) -> None:
         self._new_line()
         self._write('continue')
 
     # EXPRESSIONS
-    def with_parens(f):
-        def _f(self, node):
+    def with_parens(f: '_F') -> '_F':  # type: ignore[misc]
+        def _f(self, node) -> None:
             self._write('(')
             f(self, node)
             self._write(')')
-        return _f
+
+        return t.cast('_F', _f)
 
     bool_operators = {ast.And: 'and', ast.Or: 'or'}
 
     # BoolOp(boolop op, expr* values)
     @with_parens
-    def visit_BoolOp(self, node):
+    def visit_BoolOp(self, node) -> None:
         joiner = ' ' + self.bool_operators[node.op.__class__] + ' '
         self.visit(node.values[0])
         for value in node.values[1:]:
@@ -720,12 +748,12 @@ class ASTCodeGenerator:
         ast.BitOr: '|',
         ast.BitXor: '^',
         ast.BitAnd: '&',
-        ast.FloorDiv: '//'
+        ast.FloorDiv: '//',
     }
 
     # BinOp(expr left, operator op, expr right)
     @with_parens
-    def visit_BinOp(self, node):
+    def visit_BinOp(self, node) -> None:
         self.visit(node.left)
         self._write(' ' + self.binary_operators[node.op.__class__] + ' ')
         self.visit(node.right)
@@ -738,13 +766,13 @@ class ASTCodeGenerator:
     }
 
     # UnaryOp(unaryop op, expr operand)
-    def visit_UnaryOp(self, node):
+    def visit_UnaryOp(self, node) -> None:
         self._write(self.unary_operators[node.op.__class__] + ' ')
         self.visit(node.operand)
 
     # Lambda(arguments args, expr body)
     @with_parens
-    def visit_Lambda(self, node):
+    def visit_Lambda(self, node) -> None:
         self._write('lambda ')
         self.visit(node.args)
         self._write(': ')
@@ -752,7 +780,7 @@ class ASTCodeGenerator:
 
     # IfExp(expr test, expr body, expr orelse)
     @with_parens
-    def visit_IfExp(self, node):
+    def visit_IfExp(self, node) -> None:
         self.visit(node.body)
         self._write(' if ')
         self.visit(node.test)
@@ -760,7 +788,7 @@ class ASTCodeGenerator:
         self.visit(node.orelse)
 
     # Dict(expr* keys, expr* values)
-    def visit_Dict(self, node):
+    def visit_Dict(self, node) -> None:
         self._write('{')
         for key, value in zip(node.keys, node.values):
             self.visit(key)
@@ -769,7 +797,7 @@ class ASTCodeGenerator:
             self._write(', ')
         self._write('}')
 
-    def visit_Set(self, node):
+    def visit_Set(self, node) -> None:
         self._write('{')
         elts = list(node.elts)
         last = elts.pop()
@@ -780,7 +808,7 @@ class ASTCodeGenerator:
         self._write('}')
 
     # DictComp(expr key, expr value, comprehension* generators)
-    def visit_DictComp(self, node):
+    def visit_DictComp(self, node) -> None:
         self._write('{')
         self.visit(node.key)
         self._write(': ')
@@ -797,7 +825,7 @@ class ASTCodeGenerator:
         self._write('}')
 
     # ListComp(expr elt, comprehension* generators)
-    def visit_ListComp(self, node):
+    def visit_ListComp(self, node) -> None:
         self._write('[')
         self.visit(node.elt)
         for generator in node.generators:
@@ -812,7 +840,7 @@ class ASTCodeGenerator:
         self._write(']')
 
     # GeneratorExp(expr elt, comprehension* generators)
-    def visit_GeneratorExp(self, node):
+    def visit_GeneratorExp(self, node) -> None:
         self._write('(')
         self.visit(node.elt)
         for generator in node.generators:
@@ -827,7 +855,7 @@ class ASTCodeGenerator:
         self._write(')')
 
     # SetComp(expr elt, comprehension* generators)
-    def visit_SetComp(self, node):
+    def visit_SetComp(self, node) -> None:
         self._write('{')
         self.visit(node.elt)
         for generator in node.generators:
@@ -842,7 +870,7 @@ class ASTCodeGenerator:
                 self._write('}')
 
     # Yield(expr? value)
-    def visit_Yield(self, node):
+    def visit_Yield(self, node) -> None:
         self._write('yield')
         if getattr(node, 'value', None):
             self._write(' ')
@@ -863,7 +891,7 @@ class ASTCodeGenerator:
 
     # Compare(expr left, cmpop* ops, expr* comparators)
     @with_parens
-    def visit_Compare(self, node):
+    def visit_Compare(self, node) -> None:
         self.visit(node.left)
         for op, comparator in zip(node.ops, node.comparators):
             self._write(' ' + self.comparison_operators[op.__class__] + ' ')
@@ -871,7 +899,7 @@ class ASTCodeGenerator:
 
     # Call(expr func, expr* args, keyword* keywords,
     #                         expr? starargs, expr? kwargs)
-    def visit_Call(self, node):
+    def visit_Call(self, node) -> None:
         self.visit(node.func)
         self._write('(')
         first = True
@@ -896,37 +924,37 @@ class ASTCodeGenerator:
         self._write(')')
 
     # Repr(expr value)
-    def visit_Repr(self, node):
+    def visit_Repr(self, node) -> None:
         self._write('`')
         self.visit(node.value)
         self._write('`')
 
     # Constant(object value)
-    def visit_Constant(self, node):
+    def visit_Constant(self, node) -> None:
         if node.value is Ellipsis:
             self._write('...')
         else:
             self._write(repr(node.value))
 
     # Num(object n)
-    def visit_Num(self, node):
+    def visit_Num(self, node) -> None:
         self._write(repr(node.n))
 
     # Str(string s)
-    def visit_Str(self, node):
+    def visit_Str(self, node) -> None:
         self._write(repr(node.s))
 
-    def visit_Ellipsis(self, node):
+    def visit_Ellipsis(self, node) -> None:
         self._write('...')
 
     # Attribute(expr value, identifier attr, expr_context ctx)
-    def visit_Attribute(self, node):
+    def visit_Attribute(self, node) -> None:
         self.visit(node.value)
         self._write('.')
         self._write(node.attr)
 
     # Subscript(expr value, slice slice, expr_context ctx)
-    def visit_Subscript(self, node):
+    def visit_Subscript(self, node) -> None:
         self.visit(node.value)
         self._write('[')
         if isinstance(node.slice, ast.Tuple) and node.slice.elts:
@@ -944,7 +972,7 @@ class ASTCodeGenerator:
         self._write(']')
 
     # Slice(expr? lower, expr? upper, expr? step)
-    def visit_Slice(self, node, subscription=False):
+    def visit_Slice(self, node, subscription: bool = False) -> None:
         if subscription:
             if getattr(node, 'lower', None) is not None:
                 self.visit(node.lower)
@@ -964,11 +992,11 @@ class ASTCodeGenerator:
             self._write(')')
 
     # Index(expr value)
-    def visit_Index(self, node):
+    def visit_Index(self, node) -> None:
         self.visit(node.value)
 
     # ExtSlice(slice* dims)
-    def visit_ExtSlice(self, node):
+    def visit_ExtSlice(self, node) -> None:
         self.visit(node.dims[0])
         if len(node.dims) == 1:
             self._write(', ')
@@ -978,16 +1006,16 @@ class ASTCodeGenerator:
                 self.visit(dim)
 
     # Starred(expr value, expr_context ctx)
-    def visit_Starred(self, node):
+    def visit_Starred(self, node) -> None:
         self._write('*')
         self.visit(node.value)
 
     # Name(identifier id, expr_context ctx)
-    def visit_Name(self, node):
+    def visit_Name(self, node) -> None:
         self._write(node.id)
 
     # List(expr* elts, expr_context ctx)
-    def visit_List(self, node):
+    def visit_List(self, node) -> None:
         self._write('[')
         for elt in node.elts:
             self.visit(elt)
@@ -995,7 +1023,7 @@ class ASTCodeGenerator:
         self._write(']')
 
     # Tuple(expr *elts, expr_context ctx)
-    def visit_Tuple(self, node):
+    def visit_Tuple(self, node) -> None:
         self._write('(')
         for elt in node.elts:
             self.visit(elt)
@@ -1003,12 +1031,12 @@ class ASTCodeGenerator:
         self._write(')')
 
     # NameConstant(singleton value)
-    def visit_NameConstant(self, node):
+    def visit_NameConstant(self, node) -> None:
         self._write(str(node.value))
 
 
 class AnnotationAwareVisitor(ast.NodeVisitor):
-    def visit(self, node):
+    def visit(self, node) -> None:
         annotation = node_annotations.get(node)
         if annotation is not None:
             assert hasattr(annotation, '_fields')
@@ -1033,11 +1061,11 @@ class NameLookupRewriteVisitor(AnnotationAwareVisitor):
         self.visit(node)
         return self.transformed
 
-    def visit_arg(self, node):
+    def visit_arg(self, node) -> None:
         scope = self.scopes[-1]
         scope.add(node.arg)
 
-    def visit_Name(self, node):
+    def visit_Name(self, node) -> None:
         scope = self.scopes[-1]
         if isinstance(node.ctx, ast.Param):
             scope.add(node.id)
@@ -1045,14 +1073,14 @@ class NameLookupRewriteVisitor(AnnotationAwareVisitor):
             self.transformed.add(node.id)
             self.apply_transform(node)
 
-    def visit_FunctionDef(self, node):
+    def visit_FunctionDef(self, node) -> None:
         self.scopes[-1].add(node.name)
 
-    def visit_alias(self, node):
+    def visit_alias(self, node) -> None:
         name = node.asname if node.asname is not None else node.name
         self.scopes[-1].add(name)
 
-    def visit_Lambda(self, node):
+    def visit_Lambda(self, node) -> None:
         self.scopes.append(set())
         try:
             self.visit(node.args)
@@ -1065,6 +1093,6 @@ class ItemLookupOnAttributeErrorVisitor(AnnotationAwareVisitor):
     def __init__(self, transform):
         self.transform = transform
 
-    def visit_Attribute(self, node):
+    def visit_Attribute(self, node) -> None:
         self.generic_visit(node)
         self.apply_transform(node)

--- a/src/chameleon/astutil.py
+++ b/src/chameleon/astutil.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import MutableMapping
     from typing import TypeVar
-
     from typing_extensions import TypeAlias
 
     _F = TypeVar('_F', bound=Callable[..., Any])

--- a/src/chameleon/benchmark.py
+++ b/src/chameleon/benchmark.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import time

--- a/src/chameleon/codegen.py
+++ b/src/chameleon/codegen.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import builtins
 import textwrap

--- a/src/chameleon/codegen.py
+++ b/src/chameleon/codegen.py
@@ -26,18 +26,19 @@ NATIVE_NUMBERS = int, float, bool
 
 
 def template(
-        source,
-        mode='exec',
-        is_func=False,
-        func_args=(),
-        func_defaults=(),
-        **kw):
+    source,
+    mode='exec',
+    is_func: bool = False,
+    func_args=(),
+    func_defaults=(),
+    **kw,
+):
     def wrapper(*vargs, **kwargs):
         symbols = dict(zip(args, vargs + defaults))
         symbols.update(kwargs)
 
         class Visitor(ast.NodeVisitor):
-            def visit_FunctionDef(self, node):
+            def visit_FunctionDef(self, node) -> None:
                 self.generic_visit(node)
 
                 name = symbols.get(node.name, self)
@@ -49,7 +50,7 @@ def template(
                         decorator_list=getattr(node, "decorator_list", []),
                     )
 
-            def visit_Name(self, node):
+            def visit_Name(self, node) -> None:
                 value = symbols.get(node.id, self)
                 if value is not self:
                     if isinstance(value, str):
@@ -175,21 +176,23 @@ class TemplateCodeGenerator(ASTCodeGenerator):
         node = self.imports.get(value)
         if node is None:
             # we come up with a unique symbol based on the class name
-            name = "_%s" % getattr(value, '__name__', str(value)).\
-                   rsplit('.', 1)[-1]
+            name = (
+                "_%s"
+                % getattr(value, '__name__', str(value)).rsplit('.', 1)[-1]
+            )
             node = load(name)
             self.imports[value] = store(node.id)
 
         return node
 
-    def visit(self, node):
+    def visit(self, node) -> None:
         annotation = node_annotations.get(node)
         if annotation is None:
             super().visit(node)
         else:
             self.visit(annotation)
 
-    def visit_Comment(self, node):
+    def visit_Comment(self, node) -> None:
         if node.stmt is None:
             self._new_line()
         else:
@@ -199,15 +202,15 @@ class TemplateCodeGenerator(ASTCodeGenerator):
             self._new_line()
             self._write("{}#{}".format(node.space, line))
 
-    def visit_Builtin(self, node):
+    def visit_Builtin(self, node) -> None:
         name = load(node.id)
         self.visit(name)
 
-    def visit_Symbol(self, node):
+    def visit_Symbol(self, node) -> None:
         node = self.require(node.value)
         self.visit(node)
 
-    def visit_Static(self, node):
+    def visit_Static(self, node) -> None:
         if node.name is None:
             name = "_static_%s" % str(id(node.value)).replace('-', '_')
         else:
@@ -216,6 +219,6 @@ class TemplateCodeGenerator(ASTCodeGenerator):
         node = self.define(name, node.value)
         self.visit(node)
 
-    def visit_TokenRef(self, node):
+    def visit_TokenRef(self, node) -> None:
         self.tokens.append((node.pos, node.length))
         super().visit(ast.Num(n=node.pos))

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -85,14 +85,12 @@ else:
     LIST = template("[]", mode="eval")
 
 
-def identifier(prefix, suffix=None):
+def identifier(prefix, suffix=None) -> str:
     return "__{}_{}".format(prefix, mangle(suffix or id(prefix)))
 
 
 def mangle(string):
-    return RE_MANGLE.sub(
-        '_', str(string)
-    ).replace('\n', '').replace('-', '_')
+    return RE_MANGLE.sub('_', str(string)).replace('\n', '').replace('-', '_')
 
 
 def load_econtext(name):
@@ -305,18 +303,27 @@ class Scope(Node):
 
 class Interpolator:
     braces_required_regex = re.compile(
-        r'(\$)?\$({(?P<expression>.*)})',
-        re.DOTALL)
+        r'(\$)?\$({(?P<expression>.*)})', re.DOTALL
+    )
 
     braces_optional_regex = re.compile(
         r'(\$)?\$({(?P<expression>.*)}|(?P<variable>[A-Za-z][A-Za-z0-9_]*))',
-        re.DOTALL)
+        re.DOTALL,
+    )
 
-    def __init__(self, expression, braces_required, translate=False,
-                 decode_htmlentities=False):
+    def __init__(
+        self,
+        expression,
+        braces_required,
+        translate: bool = False,
+        decode_htmlentities: bool = False,
+    ) -> None:
         self.expression = expression
-        self.regex = self.braces_required_regex if braces_required else \
-            self.braces_optional_regex
+        self.regex = (
+            self.braces_required_regex
+            if braces_required
+            else self.braces_optional_regex
+        )
         self.translate = translate
         self.decode_htmlentities = decode_htmlentities
 
@@ -515,8 +522,14 @@ class ExpressionEngine:
 
     supported_char_escape_set = {'&', '<', '>'}
 
-    def __init__(self, parser, char_escape=(),
-                 default=None, default_marker=None, literal_false=True):
+    def __init__(
+        self,
+        parser,
+        char_escape=(),
+        default=None,
+        default_marker=None,
+        literal_false: bool = True,
+    ) -> None:
         self._parser = parser
         self._char_escape = char_escape
         self._default = default
@@ -531,10 +544,11 @@ class ExpressionEngine:
         compiler = self.parse(string)
         return compiler(string, target)
 
-    def parse(self, string, handle_errors=True, char_escape=None):
+    def parse(self, string, handle_errors: bool = True, char_escape=None):
         expression = self._parser(string)
         compiler = self.get_compiler(
-            expression, string, handle_errors, char_escape)
+            expression, string, handle_errors, char_escape
+        )
         return ExpressionCompiler(compiler, self)
 
     def get_compiler(self, expression, string, handle_errors, char_escape):
@@ -627,7 +641,7 @@ class ExpressionEngine:
 
 
 class ExpressionCompiler:
-    def __init__(self, compiler, engine):
+    def __init__(self, compiler, engine) -> None:
         self.compiler = compiler
         self.engine = engine
 
@@ -756,7 +770,7 @@ class NameTransform:
 
     """
 
-    def __init__(self, builtins, aliases, internals):
+    def __init__(self, builtins, aliases, internals) -> None:
         self.builtins = builtins
         self.aliases = aliases
         self.internals = internals
@@ -805,7 +819,9 @@ class ExpressionTransform:
 
     loads_symbol = Symbol(pickle.loads)
 
-    def __init__(self, engine_factory, cache, visitor, strict=True):
+    def __init__(
+        self, engine_factory, cache, visitor, strict: bool = True
+    ) -> None:
         self.engine_factory = engine_factory
         self.cache = cache
         self.strict = strict
@@ -970,15 +986,22 @@ class Compiler:
     defaults = {
         'translate': Symbol(simple_translate),
         'decode': Builtin("str"),
-        'on_error_handler': Builtin("str")
+        'on_error_handler': Builtin("str"),
     }
 
     lock = threading.Lock()
 
     global_builtins = set(builtins.__dict__)
 
-    def __init__(self, engine_factory, node, filename, source,
-                 builtins={}, strict=True):
+    def __init__(
+        self,
+        engine_factory,
+        node,
+        filename,
+        source,
+        builtins={},
+        strict=True,
+    ):
         self._scopes = [set()]
         self._expression_cache = {}
         self._translations = []
@@ -987,8 +1010,7 @@ class Compiler:
         self._macros = []
         self._current_slot = []
 
-        internals = COMPILER_INTERNALS_OR_DISALLOWED | \
-            set(self.defaults)
+        internals = COMPILER_INTERNALS_OR_DISALLOWED | set(self.defaults)
 
         transform = NameTransform(
             self.global_builtins | set(builtins),
@@ -1019,14 +1041,14 @@ class Compiler:
             class Generator(TemplateCodeGenerator):
                 scopes = [Scope()]
 
-                def visit_EmitText(self, node):
+                def visit_EmitText(self, node) -> None:
                     append = load(self.scopes[-1].append or "__append")
                     for node in template(
-                        "append(s)", append=append, s=ast.Str(
-                            s=node.s)):
+                        "append(s)", append=append, s=ast.Str(s=node.s)
+                    ):
                         self.visit(node)
 
-                def visit_Scope(self, node):
+                def visit_Scope(self, node) -> None:
                     self.scopes.append(node)
                     body = list(node.body)
                     swap(body, load(node.append), "__append")
@@ -1718,7 +1740,8 @@ class Compiler:
                         defaults=[
                             load("__i18n_domain"),
                             load("__i18n_context"),
-                            load("target_language"),],
+                            load("target_language"),
+                        ],
                     ),
                     body=body or [
                         ast.Pass()],

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import builtins
 import collections

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -57,8 +57,6 @@ from chameleon.utils import join
 from chameleon.utils import safe_native
 
 
-long = int
-
 log = logging.getLogger('chameleon.compiler')
 
 COMPILER_INTERNALS_OR_DISALLOWED = {
@@ -68,7 +66,6 @@ COMPILER_INTERNALS_OR_DISALLOWED = {
     "str",
     "int",
     "float",
-    "long",
     "len",
     "bool",
     "None",
@@ -155,9 +152,9 @@ emit_bool = template(is_func=True,
 
 
 emit_convert = template(is_func=True,
-                        func_args=('target', 'encoded', 'str', 'long', 'type',
+                        func_args=('target', 'encoded', 'str', 'type',
                                    'default_marker', 'default'),
-                        func_defaults=(bytes, str, long, type, None),
+                        func_defaults=(bytes, str, type, None),
                         source=r"""
     if target is None:
         pass
@@ -169,7 +166,7 @@ emit_convert = template(is_func=True,
         if __tt is encoded:
             target = decode(target)
         elif __tt is not str:
-            if __tt is int or __tt is float or __tt is long:
+            if __tt is int or __tt is float:
                 target = str(target)
             else:
                 render = getattr(target, "__html__", None)
@@ -189,8 +186,8 @@ emit_convert = template(is_func=True,
 
 emit_func_convert = template(
     is_func=True, func_args=(
-        'func', 'encoded', 'str', 'long', 'type'), func_defaults=(
-            bytes, str, long, type), source=r"""
+        'func', 'encoded', 'str', 'type'), func_defaults=(
+            bytes, str, type), source=r"""
     def func(target):
         if target is None:
             return
@@ -200,7 +197,7 @@ emit_func_convert = template(
         if __tt is encoded:
             target = decode(target)
         elif __tt is not str:
-            if __tt is int or __tt is float or __tt is long:
+            if __tt is int or __tt is float:
                 target = str(target)
             else:
                 render = getattr(target, "__html__", None)
@@ -237,8 +234,8 @@ emit_translate = template(is_func=True,
 
 emit_func_convert_and_escape = template(
     is_func=True,
-    func_args=('func', 'str', 'long', 'type', 'encoded'),
-    func_defaults=(str, long, type, bytes,),
+    func_args=('func', 'str', 'type', 'encoded'),
+    func_defaults=(str, type, bytes,),
     source=r"""
     def func(target, quote, quote_entity, default, default_marker):
         if target is None:
@@ -252,7 +249,7 @@ emit_func_convert_and_escape = template(
         if __tt is encoded:
             target = decode(target)
         elif __tt is not str:
-            if __tt is int or __tt is float or __tt is long:
+            if __tt is int or __tt is float:
                 return str(target)
             render = getattr(target, "__html__", None)
             if render is None:

--- a/src/chameleon/config.py
+++ b/src/chameleon/config.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 import os
-import typing as t
 
 
 log = logging.getLogger('chameleon.config')
@@ -29,7 +30,7 @@ DEBUG_MODE = environment.pop('debug', 'false').lower() in TRUE
 # If a cache directory is specified, template source code will be
 # persisted on disk and reloaded between sessions
 path = environment.pop('cache', None)
-CACHE_DIRECTORY: t.Optional[str]
+CACHE_DIRECTORY: str | None
 if path is not None:  # pragma: no cover
     CACHE_DIRECTORY = os.path.abspath(path)
     if not os.path.exists(CACHE_DIRECTORY):

--- a/src/chameleon/config.py
+++ b/src/chameleon/config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import typing as t
 
 
 log = logging.getLogger('chameleon.config')
@@ -15,8 +16,7 @@ TRUE = ('y', 'yes', 't', 'true', 'on', '1')
 # If eager parsing is enabled, templates are parsed upon
 # instantiation, rather than when first called upon; this mode is
 # useful for verifying validity of templates across a project
-EAGER_PARSING = environment.pop('eager', 'false')
-EAGER_PARSING = EAGER_PARSING.lower() in TRUE
+EAGER_PARSING = environment.pop('eager', 'false').lower() in TRUE
 
 # Debug mode is mostly useful for debugging the template engine
 # itself. When enabled, generated source code is written to disk to
@@ -24,12 +24,12 @@ EAGER_PARSING = EAGER_PARSING.lower() in TRUE
 # output. Also, the generated source code is available in the
 # ``source`` attribute of the template instance if compilation
 # succeeded.
-DEBUG_MODE = environment.pop('debug', 'false')
-DEBUG_MODE = DEBUG_MODE.lower() in TRUE
+DEBUG_MODE = environment.pop('debug', 'false').lower() in TRUE
 
 # If a cache directory is specified, template source code will be
 # persisted on disk and reloaded between sessions
 path = environment.pop('cache', None)
+CACHE_DIRECTORY: t.Optional[str]
 if path is not None:  # pragma: no cover
     CACHE_DIRECTORY = os.path.abspath(path)
     if not os.path.exists(CACHE_DIRECTORY):
@@ -41,8 +41,7 @@ else:
     CACHE_DIRECTORY = None
 
 # When auto-reload is enabled, templates are reloaded on file change.
-AUTO_RELOAD = environment.pop('reload', 'false')
-AUTO_RELOAD = AUTO_RELOAD.lower() in TRUE
+AUTO_RELOAD = environment.pop('reload', 'false').lower() in TRUE
 
 for key in environment:
     log.warning(

--- a/src/chameleon/exc.py
+++ b/src/chameleon/exc.py
@@ -6,8 +6,8 @@ from chameleon.tokenize import Token
 from chameleon.utils import create_formatted_exception
 from chameleon.utils import safe_native
 
+
 if t.TYPE_CHECKING:
-    from _typeshed import StrPath
     import typing_extensions as te
 
 

--- a/src/chameleon/exc.py
+++ b/src/chameleon/exc.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import traceback
-import typing as t
+from typing import TYPE_CHECKING
 
 from chameleon.config import SOURCE_EXPRESSION_MARKER_LENGTH as LENGTH
 from chameleon.tokenize import Token
@@ -7,8 +9,8 @@ from chameleon.utils import create_formatted_exception
 from chameleon.utils import safe_native
 
 
-if t.TYPE_CHECKING:
-    import typing_extensions as te
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 
 def compute_source_marker(line, column, expression, size):
@@ -145,7 +147,7 @@ class TemplateError(Exception):
 
     """
 
-    args: t.Tuple[str, Token]
+    args: tuple[str, Token]
 
     def __init__(self, msg: str, token: Token) -> None:
         if not isinstance(token, Token):
@@ -153,7 +155,7 @@ class TemplateError(Exception):
 
         Exception.__init__(self, msg, token)
 
-    def __copy__(self) -> "te.Self":
+    def __copy__(self) -> Self:
         inst = Exception.__new__(type(self))
         inst.args = self.args
         return inst
@@ -215,7 +217,7 @@ class TemplateError(Exception):
         return self.token.filename
 
     @property
-    def location(self) -> t.Tuple[int, int]:
+    def location(self) -> tuple[int, int]:
         return self.token.location
 
     @property

--- a/src/chameleon/i18n.py
+++ b/src/chameleon/i18n.py
@@ -12,10 +12,16 @@
 #
 ##############################################################################
 
+from __future__ import annotations
+
 import re
-import typing as t
+from typing import TYPE_CHECKING
 
 from chameleon.exc import CompilationError
+
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 NAME_RE = r"[a-zA-Z][-a-zA-Z0-9_]*"
@@ -51,13 +57,13 @@ except ImportError:   # pragma: no cover
     pass
 else:   # pragma: no cover
     def fast_translate(
-        msgid: t.Optional[str],
-        domain: t.Optional[str] = None,
-        mapping: t.Optional[t.Mapping[str, object]] = None,
-        context: t.Optional[str] = None,
-        target_language: t.Optional[str] = None,
-        default: t.Optional[str] = None
-    ) -> t.Optional[str]:
+        msgid: str | None,
+        domain: str | None = None,
+        mapping: Mapping[str, object] | None = None,
+        context: str | None = None,
+        target_language: str | None = None,
+        default: str | None = None
+    ) -> str | None:
 
         if msgid is None:
             return None
@@ -84,11 +90,11 @@ else:   # pragma: no cover
 
 def simple_translate(
     msgid: str,
-    domain: t.Optional[str] = None,
-    mapping: t.Optional[t.Mapping[str, object]] = None,
-    context: t.Optional[str] = None,
-    target_language: t.Optional[str] = None,
-    default: t.Optional[str] = None
+    domain: str | None = None,
+    mapping: Mapping[str, object] | None = None,
+    context: str | None = None,
+    target_language: str | None = None,
+    default: str | None = None
 ) -> str:
 
     if default is None:
@@ -98,7 +104,7 @@ def simple_translate(
         mapping = getattr(msgid, "mapping", None)
 
     if mapping:
-        def replace(match: t.Match[str]) -> str:
+        def replace(match: re.Match[str]) -> str:
             whole, param1, param2 = match.groups()
             return str(mapping.get(param1 or param2, whole))
         return _interp_regex.sub(replace, default)

--- a/src/chameleon/nodes.py
+++ b/src/chameleon/nodes.py
@@ -1,3 +1,5 @@
+import typing as t
+
 from chameleon.astutil import Node
 
 
@@ -29,6 +31,7 @@ class CodeBlock(Node):
 class Value(Node):
     """Expression object value."""
 
+    _fields: t.ClassVar[t.Tuple[str, ...]]
     _fields = "value", "default", "default_marker"
 
     default = None
@@ -42,7 +45,10 @@ class Value(Node):
             line, column = 0, 0
 
         return "<%s %r (%d:%d)>" % (
-            type(self).__name__, self.value, line, column
+            type(self).__name__,
+            self.value,
+            line,
+            column,
         )
 
 
@@ -50,7 +56,11 @@ class Substitution(Value):
     """Expression value for text substitution."""
 
     _fields = (
-        "value", "char_escape", "default", "default_marker", "literal_false"
+        "value",
+        "char_escape",
+        "default",
+        "default_marker",
+        "literal_false",
     )
 
     default = None
@@ -64,7 +74,7 @@ class Boolean(Value):
 class Negate(Node):
     """Wraps an expression with a negation."""
 
-    _fields = "value",
+    _fields = ("value",)
 
 
 class Element(Node):
@@ -83,7 +93,14 @@ class Attribute(Node):
     """Element attribute."""
 
     _fields = (
-        "name", "expression", "quote", "eq", "space", "default", "filters")
+        "name",
+        "expression",
+        "quote",
+        "eq",
+        "space",
+        "default",
+        "filters",
+    )
 
 
 class Start(Node):
@@ -123,7 +140,7 @@ class Equals(Op):
 class Logical(Node):
     """Logical operator."""
 
-    _fields = "expressions",
+    _fields = ("expressions",)
 
 
 class And(Logical):
@@ -145,6 +162,7 @@ class Cache(Node):
     ``node``.
     """
 
+    _fields: t.ClassVar[t.Tuple[str, ...]]
     _fields = "expressions", "node"
 
 
@@ -153,12 +171,13 @@ class Cancel(Cache):
 
 
 class Copy(Node):
-    _fields = "expression",
+    _fields = ("expression",)
 
 
 class Assignment(Node):
     """Variable assignment."""
 
+    _fields: t.ClassVar[t.Tuple[str, ...]]
     _fields = "names", "expression", "local"
 
 
@@ -194,24 +213,32 @@ class Program(Node):
 
 
 class Module(Node):
-    _fields = "name", "program",
+    _fields = (
+        "name",
+        "program",
+    )
 
 
 class Context(Node):
-    _fields = "node",
+    _fields = ("node",)
 
 
 class Text(Node):
     """Static text output."""
 
-    _fields = "value",
+    _fields = ("value",)
 
 
 class Interpolation(Node):
     """String interpolation output."""
 
     _fields = (
-        "value", "braces_required", "translation", "default", "default_marker")
+        "value",
+        "braces_required",
+        "translation",
+        "default",
+        "default_marker",
+    )
 
 
 class Replace(Node):
@@ -257,7 +284,7 @@ class OnError(Node):
 class UseInternalMacro(Node):
     """Use internal macro (defined inside same program)."""
 
-    _fields = "name",
+    _fields = ("name",)
 
 
 class FillSlot(Node):

--- a/src/chameleon/nodes.py
+++ b/src/chameleon/nodes.py
@@ -1,4 +1,6 @@
-import typing as t
+from __future__ import annotations
+
+from typing import ClassVar
 
 from chameleon.astutil import Node
 
@@ -31,7 +33,7 @@ class CodeBlock(Node):
 class Value(Node):
     """Expression object value."""
 
-    _fields: t.ClassVar[t.Tuple[str, ...]]
+    _fields: ClassVar[tuple[str, ...]]
     _fields = "value", "default", "default_marker"
 
     default = None
@@ -162,7 +164,7 @@ class Cache(Node):
     ``node``.
     """
 
-    _fields: t.ClassVar[t.Tuple[str, ...]]
+    _fields: ClassVar[tuple[str, ...]]
     _fields = "expressions", "node"
 
 
@@ -177,7 +179,7 @@ class Copy(Node):
 class Assignment(Node):
     """Variable assignment."""
 
-    _fields: t.ClassVar[t.Tuple[str, ...]]
+    _fields: ClassVar[tuple[str, ...]]
     _fields = "names", "expression", "local"
 
 

--- a/src/chameleon/parser.py
+++ b/src/chameleon/parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import re
 from collections import OrderedDict

--- a/src/chameleon/parser.py
+++ b/src/chameleon/parser.py
@@ -113,7 +113,7 @@ def parse_tag(token, namespace, restricted_namespace):
     return node
 
 
-def update_namespace(attributes, namespace):
+def update_namespace(attributes, namespace) -> None:
     # possibly update namespaces; we do this in a separate step
     # because this assignment is irrespective of order
     for attribute in attributes:
@@ -150,14 +150,14 @@ def unpack_attributes(attributes, namespace, default, restricted_namespace):
     return namespaced
 
 
-def identify(string):
+def identify(string) -> str:
     if string.startswith("<"):
         if string.startswith("<!--"):
             m = match_double_hyphen.search(string[4:])
             if m is not None:
                 raise ParseError(
                     "The string '--' is not allowed in a comment.",
-                    string[4 + m.start():4 + m.end()]
+                    string[4 + m.start():4 + m.end()],
                 )
             return "comment"
         if string.startswith("<![CDATA["):

--- a/src/chameleon/program.py
+++ b/src/chameleon/program.py
@@ -1,8 +1,3 @@
-try:
-    str = unicode
-except NameError:
-    long = int
-
 from chameleon.namespaces import XML_NS
 from chameleon.namespaces import XMLNS_NS
 from chameleon.parser import ElementParser
@@ -23,14 +18,15 @@ class ElementProgram:
 
     restricted_namespace = True
 
-    def __init__(self, source, mode="xml", filename=None, tokenizer=None):
+    def __init__(
+        self, source, mode="xml", filename=None, tokenizer=None
+    ) -> None:
         if tokenizer is None:
             tokenizer = self.tokenizers[mode]
         tokens = tokenizer(source, filename)
         parser = ElementParser(
-            tokens,
-            self.DEFAULT_NAMESPACES,
-            self.restricted_namespace)
+            tokens, self.DEFAULT_NAMESPACES, self.restricted_namespace
+        )
 
         self.body = []
 

--- a/src/chameleon/program.py
+++ b/src/chameleon/program.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from chameleon.namespaces import XML_NS
 from chameleon.namespaces import XMLNS_NS
 from chameleon.parser import ElementParser

--- a/src/chameleon/tal.py
+++ b/src/chameleon/tal.py
@@ -12,6 +12,8 @@
 #
 ##############################################################################
 
+from __future__ import annotations
+
 import copy
 import re
 

--- a/src/chameleon/tal.py
+++ b/src/chameleon/tal.py
@@ -217,28 +217,20 @@ class RepeatItem:
 
     __allow_access_to_unprotected_subobjects__ = True
 
-    def __init__(self, iterator, length):
+    def __init__(self, iterator, length) -> None:
         self.length = length
         self._iterator = iterator
 
     def __iter__(self):
         return self._iterator
 
-    try:
-        iter(()).__len__
-    except AttributeError:
-        @descriptorint
-        def index(self):
-            try:
-                remaining = self._iterator.__length_hint__()
-            except AttributeError:
-                remaining = len(tuple(copy.copy(self._iterator)))
-            return self.length - remaining - 1
-    else:
-        @descriptorint
-        def index(self):
-            remaining = self._iterator.__len__()
-            return self.length - remaining - 1
+    @descriptorint
+    def index(self):
+        try:
+            remaining = self._iterator.__length_hint__()
+        except AttributeError:
+            remaining = len(tuple(copy.copy(self._iterator)))
+        return self.length - remaining - 1
 
     @descriptorint
     def start(self):
@@ -425,7 +417,7 @@ class RepeatDict:
 
     __slots__ = "__setitem__", "__getitem__"
 
-    def __init__(self, d):
+    def __init__(self, d) -> None:
         self.__setitem__ = d.__setitem__
         self.__getitem__ = d.__getitem__
 

--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -269,7 +269,7 @@ class PythonExpr(TalesExpr):
 class ImportExpr:
     re_dotted = re.compile(r'^[A-Za-z.]+$')
 
-    def __init__(self, expression):
+    def __init__(self, expression) -> None:
         self.expression = expression
 
     def __call__(self, target, engine):
@@ -294,7 +294,7 @@ class NotExpr:
     False
     """
 
-    def __init__(self, expression):
+    def __init__(self, expression) -> None:
         self.expression = expression
 
     def __call__(self, target, engine):
@@ -314,7 +314,7 @@ class StructureExpr:
 
     wrapper_class = Symbol(Markup)
 
-    def __init__(self, expression):
+    def __init__(self, expression) -> None:
         self.expression = expression
 
     def __call__(self, target, engine):
@@ -323,7 +323,7 @@ class StructureExpr:
         return body + template(
             "target = wrapper(target)",
             target=target,
-            wrapper=self.wrapper_class
+            wrapper=self.wrapper_class,
         )
 
 
@@ -336,7 +336,7 @@ class IdentityExpr:
     42
     """
 
-    def __init__(self, expression):
+    def __init__(self, expression) -> None:
         self.expression = expression
 
     def __call__(self, target, engine):
@@ -456,7 +456,7 @@ class StringExpr:
     'There are 11 characters in \"hello world\"'
     """
 
-    def __init__(self, expression, braces_required=False):
+    def __init__(self, expression, braces_required: bool = False) -> None:
         # The code relies on the expression being a token string
         if not isinstance(expression, Token):
             expression = Token(expression, 0)
@@ -470,7 +470,7 @@ class StringExpr:
 class ProxyExpr(TalesExpr):
     braces_required = False
 
-    def __init__(self, name, expression, ignore_prefix=True):
+    def __init__(self, name, expression, ignore_prefix: bool = True) -> None:
         super().__init__(expression)
         self.ignore_prefix = ignore_prefix
         self.name = name
@@ -509,7 +509,7 @@ class ExistsExpr:
 
     exceptions = AttributeError, LookupError, TypeError, NameError
 
-    def __init__(self, expression):
+    def __init__(self, expression) -> None:
         self.expression = expression
 
     def __call__(self, target, engine):
@@ -533,7 +533,7 @@ class ExistsExpr:
 
 
 class ExpressionParser:
-    def __init__(self, factories, default):
+    def __init__(self, factories, default) -> None:
         self.factories = factories
         self.default = default
 
@@ -558,7 +558,7 @@ class ExpressionParser:
 class SimpleEngine:
     expression = PythonExpr
 
-    def __init__(self, expression=None):
+    def __init__(self, expression=None) -> None:
         if expression is not None:
             self.expression = expression
 
@@ -568,7 +568,7 @@ class SimpleEngine:
 
 
 class SimpleCompiler:
-    def __init__(self, compiler, engine):
+    def __init__(self, compiler, engine) -> None:
         self.compiler = compiler
         self.engine = engine
 

--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import re
 import sys

--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -29,7 +29,6 @@ DEFAULT_MARKER = ImportableMarker(__name__, "DEFAULT")
 split_parts = re.compile(r'(?<!\\)\|')
 match_prefix = re.compile(r'^\s*([a-z][a-z0-9\-_]*):').match
 re_continuation = re.compile(r'\\\s*$', re.MULTILINE)
-exc_clear = getattr(sys, "exc_clear", None)
 
 
 def resolve_global(value):
@@ -48,8 +47,6 @@ def test(expression, engine=None, **env):
     module = ast.Module(body)
     module = ast.fix_missing_locations(module)
     env['rcontext'] = {}
-    if exc_clear is not None:
-        env['__exc_clear'] = exc_clear
     source = TemplateCodeGenerator(module).code
     code = compile(source, '<string>', 'exec')
     exec(code, env)
@@ -159,17 +156,7 @@ class TalesExpr:
                             elts=map(resolve_global, self.exceptions),
                             ctx=ast.Load()),
                         name=None,
-                        body=body if exc_clear is None else body + [
-                            ast.Expr(
-                                ast.Call(
-                                    func=load("__exc_clear"),
-                                    args=[],
-                                    keywords=[],
-                                    starargs=None,
-                                    kwargs=None,
-                                )
-                            )
-                        ],
+                        body=body,
                     )],
                 )]
 

--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import re
-import sys
 from ast import Try
 
 from chameleon.astutil import Builtin

--- a/src/chameleon/template.py
+++ b/src/chameleon/template.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import sys
 import tempfile
+import typing as t
 
 from chameleon.compiler import Compiler
 from chameleon.config import AUTO_RELOAD
@@ -31,17 +32,23 @@ from chameleon.utils import read_xml_encoding
 from chameleon.utils import value_repr
 
 
+if t.TYPE_CHECKING:
+    from _typeshed import StrPath
+    from abc import abstractmethod
+
+    from chameleon.compiler import ExpressionEngine
+
+
 try:
     RecursionError
 except NameError:
     RecursionError = RuntimeError
 
 
-def get_package_versions():
-    try:
-        # try backport first as packages_distributions was added in Python 3.10
+def get_package_versions() -> t.List[t.Tuple[str, str]]:
+    if sys.version_info < (3, 10):
         import importlib_metadata
-    except ImportError:
+    else:
         import importlib.metadata as importlib_metadata
 
     versions = {
@@ -59,7 +66,7 @@ for name, version in get_package_versions():
 log = logging.getLogger('chameleon.template')
 
 
-def _make_module_loader():
+def _make_module_loader() -> ModuleLoader:
     remove = False
     if CACHE_DIRECTORY:
         path = CACHE_DIRECTORY
@@ -86,20 +93,22 @@ class BaseTemplate:
     """
 
     default_encoding = "utf-8"
-    default_content_type = None
+    default_content_type: t.Optional[str] = None
 
     # This attribute is strictly informational in this template class
     # and is used in exception formatting. It may be set on
     # initialization using the optional ``filename`` keyword argument.
-    filename = '<string>'
+    filename: 'StrPath' = '<string>'
 
     _cooked = False
 
+    loader: t.Union[ModuleLoader, MemoryLoader]
     if DEBUG_MODE or CACHE_DIRECTORY:
         loader = _make_module_loader()
     else:
         loader = MemoryLoader()
 
+    output_stream_factory: t.Type[t.List[str]]
     if DEBUG_MODE:
         output_stream_factory = DebuggingOutputStream
     else:
@@ -110,15 +119,20 @@ class BaseTemplate:
     # The ``builtins`` dictionary can be used by a template class to
     # add symbols which may not be redefined and which are (cheaply)
     # available in the template variable scope
-    builtins = {}
+    builtins: t.Dict[str, t.Any] = {}
 
     # The ``builtins`` dictionary is updated with this dictionary at
     # cook time. Note that it can be provided at class initialization
     # using the ``extra_builtins`` keyword argument.
-    extra_builtins = {}
+    extra_builtins: t.Dict[str, t.Any] = {}
 
     # Expression engine must be provided by subclass
-    engine = None
+    if t.TYPE_CHECKING:
+        @property
+        @abstractmethod
+        def engine(self) -> t.Callable[[], ExpressionEngine]: ...
+    else:
+        engine = None
 
     # When ``strict`` is set, expressions must be valid at compile
     # time. When not set, this is only required at evaluation time.
@@ -128,7 +142,14 @@ class BaseTemplate:
     # formatting.
     value_repr = staticmethod(value_repr)
 
-    def __init__(self, body=None, **config):
+    source: t.Optional[str]
+
+    def __init__(
+        self,
+        body: t.Union[str, bytes, None] = None,
+        **config: t.Any
+    ) -> None:
+
         self.__dict__.update(config)
 
         if body is not None:
@@ -139,25 +160,31 @@ class BaseTemplate:
         if self.__dict__.get('debug') is True:
             self.loader = _make_module_loader()
 
-    def __call__(self, **kwargs):
+    def __call__(self, **kwargs: t.Any) -> str:
         return self.render(**kwargs)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{} {}>".format(self.__class__.__name__, self.filename)
 
+    if t.TYPE_CHECKING:
+        # since we add config values to our __dict__ they can appear as
+        # arbitrary attributes, to clue the type checker into arbitary
+        # attribute access being a possibility, we annotate __getattr__
+        def __getattr__(self, name: str) -> t.Any: ...
+
     @property
-    def keep_body(self):
+    def keep_body(self) -> bool:
         # By default, we only save the template body if we're
         # in debugging mode (to save memory).
-        return self.__dict__.get('keep_body', DEBUG_MODE)
+        return self.__dict__.get('keep_body', DEBUG_MODE)  # type: ignore
 
     @property
-    def keep_source(self):
+    def keep_source(self) -> bool:
         # By default, we only save the generated source code if we're
         # in debugging mode (to save memory).
-        return self.__dict__.get('keep_source', DEBUG_MODE)
+        return self.__dict__.get('keep_source', DEBUG_MODE)  # type: ignore
 
-    def cook(self, body):
+    def cook(self, body: str) -> None:
         builtins_dict = self.builtins.copy()
         builtins_dict.update(self.extra_builtins)
         names, builtins = zip(*sorted(builtins_dict.items()))
@@ -175,15 +202,16 @@ class BaseTemplate:
         if self.keep_body:
             self.body = body
 
-    def cook_check(self):
+    def cook_check(self) -> t.Optional[bool]:
         assert self._cooked
+        return None
 
-    def parse(self, body):
+    def parse(self, body: str) -> t.Any:
         raise NotImplementedError("Must be implemented by subclass.")
 
-    def render(self, **__kw):
+    def render(self, **__kw: t.Any) -> str:
         econtext = Scope(__kw)
-        rcontext = {}
+        rcontext: t.Dict[str, t.Any] = {}
         self.cook_check()
         stream = self.output_stream_factory()
         target_language = __kw.get("target_language")
@@ -217,6 +245,7 @@ class BaseTemplate:
                     except TypeError:
                         pass
 
+                    assert exc is not None
                     raise_with_traceback(exc, tb)
 
                 raise
@@ -225,7 +254,8 @@ class BaseTemplate:
 
         return join(stream)
 
-    def write(self, body):
+    def write(self, body: t.Union[str, bytes]) -> None:
+        encoding: t.Optional[str]
         if isinstance(body, bytes):
             body, encoding, content_type = read_bytes(
                 body, self.default_encoding
@@ -243,10 +273,16 @@ class BaseTemplate:
 
         self.cook(body)
 
-    def _get_module_name(self, name):
+    def _get_module_name(self, name: str) -> str:
         return "%s.py" % name
 
-    def _cook(self, body, name, builtins):
+    def _cook(
+        self,
+        body: str,
+        name: str,
+        builtins: t.Collection[str]
+    ) -> t.Dict[str, t.Any]:
+
         filename = self._get_module_name(name)
         cooked = self.loader.get(filename)
         if cooked is None:
@@ -259,17 +295,19 @@ class BaseTemplate:
                     self.source = source
                 cooked = self.loader.build(source, filename)
             except TemplateError as exc:
-                exc.token.filename = self.filename
+                # normalize to str
+                exc.token.filename = str(self.filename)
                 raise
         elif self.keep_source:
-            module = sys.modules.get(cooked.get('__name__'))
+            module_name = cooked.get('__name__')
+            module = sys.modules.get(module_name) if module_name else None
             if module is not None:
                 self.source = inspect.getsource(module)
             else:
                 self.source = None
         return cooked
 
-    def digest(self, body, names):
+    def digest(self, body: str, names: t.Collection[str]) -> str:
         class_name = type(self).__name__.encode('utf-8')
         sha = pkg_digest.copy()
         sha.update(body.encode('utf-8', 'ignore'))
@@ -282,7 +320,7 @@ class BaseTemplate:
 
         return digest
 
-    def _compile(self, body, builtins):
+    def _compile(self, body: str, builtins: t.Collection[str]) -> str:
         program = self.parse(body)
         module = Module("initialize", program)
         compiler = Compiler(
@@ -303,13 +341,17 @@ class BaseTemplateFile(BaseTemplate):
     # performance hit
     auto_reload = AUTO_RELOAD
 
+    _v_last_read: t.Optional[float]
+
     def __init__(
-            self,
-            filename,
-            auto_reload=None,
-            package_name=None,
-            post_init_hook=None,
-            **config):
+        self,
+        filename: 'StrPath',
+        auto_reload: t.Optional[bool] = None,
+        package_name: t.Optional[str] = None,
+        post_init_hook: t.Optional[t.Callable[[], object]] = None,
+        **config: t.Any,
+    ) -> None:
+
         if package_name is None:
             # Normalize filename
             filename = os.path.abspath(
@@ -330,7 +372,7 @@ class BaseTemplateFile(BaseTemplate):
         if EAGER_PARSING:
             self.cook_check()
 
-    def cook_check(self):
+    def cook_check(self) -> bool:
         if self.auto_reload:
             mtime = self.mtime()
 
@@ -346,7 +388,7 @@ class BaseTemplateFile(BaseTemplate):
 
         return False
 
-    def mtime(self):
+    def mtime(self) -> float:
         filename = self.filename
         if self.package_name is not None:
             with import_package_resource(self.package_name) as path:
@@ -363,7 +405,7 @@ class BaseTemplateFile(BaseTemplate):
         except OSError:
             return 0
 
-    def read(self):
+    def read(self) -> str:
         if self.package_name is not None:
             with import_package_resource(self.package_name) as files:
                 path = files.joinpath(self.filename)
@@ -372,26 +414,32 @@ class BaseTemplateFile(BaseTemplate):
             with open(self.filename, "rb") as f:
                 data = f.read()
 
-        body, encoding, content_type = read_bytes(
-            data, self.default_encoding
-        )
+        body, encoding, content_type = read_bytes(data, self.default_encoding)
 
         self.content_type = content_type or self.default_content_type
         self.content_encoding = encoding
 
         return body
 
-    def _get_module_name(self, name):
+    def _get_module_name(self, name: str) -> str:
         filename = os.path.basename(str(self.filename))
         mangled = mangle(filename)
         return "{}_{}.py".format(mangled, name)
 
-    def _get_filename(self):
-        return self.__dict__.get('filename')
+    def _get_filename(self) -> str:
+        # FIXME: Shouldn't a missing filename be an error?
+        return self.__dict__.get('filename')  # type: ignore[return-value]
 
-    def _set_filename(self, filename):
+    def _set_filename(self, filename: str) -> None:
         self.__dict__['filename'] = filename
         self._v_last_read = None
         self._cooked = False
 
-    filename = property(_get_filename, _set_filename)
+    if t.TYPE_CHECKING:
+        # type checkers only understand this way of defining properties
+        @property
+        def filename(self) -> 'StrPath': ...
+        @filename.setter
+        def filename(self, filename: 'StrPath') -> None: ...
+    else:
+        filename = property(_get_filename, _set_filename)

--- a/src/chameleon/template.py
+++ b/src/chameleon/template.py
@@ -36,26 +36,19 @@ from chameleon.utils import value_repr
 
 
 if TYPE_CHECKING:
+    from _typeshed import StrPath
     from abc import abstractmethod
     from collections.abc import Callable
     from collections.abc import Collection
 
-    from _typeshed import StrPath
-
     from chameleon.compiler import ExpressionEngine
 
 
-try:
-    RecursionError
-except NameError:
-    RecursionError = RuntimeError
-
-
 def get_package_versions() -> list[tuple[str, str]]:
-    if sys.version_info < (3, 10):
-        import importlib_metadata
-    else:
+    if sys.version_info >= (3, 10):
         import importlib.metadata as importlib_metadata
+    else:
+        import importlib_metadata
 
     versions = {
         x: importlib_metadata.version(x)

--- a/src/chameleon/template.py
+++ b/src/chameleon/template.py
@@ -33,8 +33,9 @@ from chameleon.utils import value_repr
 
 
 if t.TYPE_CHECKING:
-    from _typeshed import StrPath
     from abc import abstractmethod
+
+    from _typeshed import StrPath
 
     from chameleon.compiler import ExpressionEngine
 

--- a/src/chameleon/template.py
+++ b/src/chameleon/template.py
@@ -239,7 +239,7 @@ class BaseTemplate:
 
                     try:
                         exc = create_formatted_exception(
-                            exc, cls, formatter, RenderError
+                            exc, cls, formatter, RenderError  # type: ignore
                         )
                     except TypeError:
                         pass

--- a/src/chameleon/types.py
+++ b/src/chameleon/types.py
@@ -1,5 +1,6 @@
 import typing as t
 
+
 if t.TYPE_CHECKING:
     from chameleon.tokenize import Token
 

--- a/src/chameleon/types.py
+++ b/src/chameleon/types.py
@@ -10,7 +10,6 @@ from typing import TypedDict
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Collection
-
     from typing_extensions import TypeAlias
 
     from chameleon.tokenize import Token

--- a/src/chameleon/types.py
+++ b/src/chameleon/types.py
@@ -10,7 +10,6 @@ from typing import TypedDict
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Collection
-    from collections.abc import Mapping
 
     from typing_extensions import TypeAlias
 
@@ -41,7 +40,7 @@ class TranslationFunction(Protocol):
         msgid: str,
         *,
         domain: str | None = None,
-        mapping: Mapping[str, object] | None = None,
+        mapping: dict[str, Any] | None = None,
         default: str | None = None,
         context: str | None = None
     ) -> str: ...
@@ -53,7 +52,7 @@ class TranslationFunctionWithTargetLanguage(Protocol):
         msgid: str,
         *,
         domain: str | None = None,
-        mapping: Mapping[str, object] | None = None,
+        mapping: dict[str, Any] | None = None,
         default: str | None = None,
         context: str | None = None,
         target_language: str | None = None

--- a/src/chameleon/types.py
+++ b/src/chameleon/types.py
@@ -1,0 +1,70 @@
+import typing as t
+
+if t.TYPE_CHECKING:
+    from chameleon.tokenize import Token
+
+
+ExpressionType = t.Literal[
+    'python',
+    'string',
+    'not',
+    'exists',
+    'import',
+    'structure'
+]
+
+
+class Tokenizer(t.Protocol):
+    def __call__(
+        self,
+        body: str,
+        filename: t.Optional[str] = None
+    ) -> 'Token': ...
+
+
+class TranslationFunction(t.Protocol):
+    def __call__(
+        self,
+        msgid: str,
+        *,
+        domain: t.Optional[str] = None,
+        mapping: t.Optional[t.Mapping[str, object]] = None,
+        default: t.Optional[str] = None,
+        context: t.Optional[str] = None
+    ) -> str: ...
+
+
+class TranslationFunctionWithTargetLanguage(t.Protocol):
+    def __call__(
+        self,
+        msgid: str,
+        *,
+        domain: t.Optional[str] = None,
+        mapping: t.Optional[t.Mapping[str, object]] = None,
+        default: t.Optional[str] = None,
+        context: t.Optional[str] = None,
+        target_language: t.Optional[str] = None
+    ) -> str: ...
+
+
+AnyTranslationFunction = t.Union[
+    TranslationFunction,
+    TranslationFunctionWithTargetLanguage
+]
+
+
+class PageTemplateConfig(t.TypedDict, total=False):
+    auto_reload: bool
+    default_expression: ExpressionType
+    encoding: str
+    boolean_attributes: t.Collection[str]
+    translate: AnyTranslationFunction
+    implicit_i18n_translate: bool
+    implicit_i18n_attributes: t.Set[str]
+    on_error_handler: t.Callable[[BaseException], object]
+    strict: bool
+    trim_attribute_space: bool
+    restricted_namespace: bool
+    tokenizer: Tokenizer
+    value_repr: t.Callable[[object], str]
+    default_marker: t.Any

--- a/src/chameleon/types.py
+++ b/src/chameleon/types.py
@@ -1,11 +1,23 @@
-import typing as t
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Literal
+from typing import Protocol
+from typing import TypedDict
 
 
-if t.TYPE_CHECKING:
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Collection
+    from collections.abc import Mapping
+
+    from typing_extensions import TypeAlias
+
     from chameleon.tokenize import Token
 
 
-ExpressionType = t.Literal[
+ExpressionType: TypeAlias = Literal[
     'python',
     'string',
     'not',
@@ -15,57 +27,58 @@ ExpressionType = t.Literal[
 ]
 
 
-class Tokenizer(t.Protocol):
+class Tokenizer(Protocol):
     def __call__(
         self,
         body: str,
-        filename: t.Optional[str] = None
-    ) -> 'Token': ...
+        filename: str | None = None
+    ) -> Token: ...
 
 
-class TranslationFunction(t.Protocol):
+class TranslationFunction(Protocol):
     def __call__(
         self,
         msgid: str,
         *,
-        domain: t.Optional[str] = None,
-        mapping: t.Optional[t.Mapping[str, object]] = None,
-        default: t.Optional[str] = None,
-        context: t.Optional[str] = None
+        domain: str | None = None,
+        mapping: Mapping[str, object] | None = None,
+        default: str | None = None,
+        context: str | None = None
     ) -> str: ...
 
 
-class TranslationFunctionWithTargetLanguage(t.Protocol):
+class TranslationFunctionWithTargetLanguage(Protocol):
     def __call__(
         self,
         msgid: str,
         *,
-        domain: t.Optional[str] = None,
-        mapping: t.Optional[t.Mapping[str, object]] = None,
-        default: t.Optional[str] = None,
-        context: t.Optional[str] = None,
-        target_language: t.Optional[str] = None
+        domain: str | None = None,
+        mapping: Mapping[str, object] | None = None,
+        default: str | None = None,
+        context: str | None = None,
+        target_language: str | None = None
     ) -> str: ...
 
 
-AnyTranslationFunction = t.Union[
-    TranslationFunction,
-    TranslationFunctionWithTargetLanguage
-]
+# until we drop support for 3.9 this needs to be a string literal
+AnyTranslationFunction: TypeAlias = (
+    'TranslationFunction '  # noqa: TC008
+    '| TranslationFunctionWithTargetLanguage'
+)
 
 
-class PageTemplateConfig(t.TypedDict, total=False):
+class PageTemplateConfig(TypedDict, total=False):
     auto_reload: bool
     default_expression: ExpressionType
     encoding: str
-    boolean_attributes: t.Collection[str]
+    boolean_attributes: Collection[str]
     translate: AnyTranslationFunction
     implicit_i18n_translate: bool
-    implicit_i18n_attributes: t.Set[str]
-    on_error_handler: t.Callable[[BaseException], object]
+    implicit_i18n_attributes: set[str]
+    on_error_handler: Callable[[BaseException], object]
     strict: bool
     trim_attribute_space: bool
     restricted_namespace: bool
     tokenizer: Tokenizer
-    value_repr: t.Callable[[object], str]
-    default_marker: t.Any
+    value_repr: Callable[[object], str]
+    default_marker: Any

--- a/src/chameleon/utils.py
+++ b/src/chameleon/utils.py
@@ -4,19 +4,38 @@ import codecs
 import logging
 import os
 import re
+from enum import Enum
 from html import entities as htmlentitydefs
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Generic
+from typing import Literal
 from typing import NoReturn
+from typing import TypeVar
+from typing import overload
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from collections.abc import Iterable
+    from collections.abc import Iterator
+    from collections.abc import Mapping
+    from collections.abc import Sequence
     from types import TracebackType
 
 
+_KT = TypeVar('_KT')
+_VT_co = TypeVar('_VT_co')
+
 log = logging.getLogger('chameleon.utils')
-marker = object()
+
+
+class _Marker(Enum):
+    marker = object()
+
+
+# NOTE: Enums are better markers for type narrowing
+marker: Literal[_Marker.marker] = _Marker.marker
 
 
 def safe_native(s: str | bytes, encoding: str = 'utf-8') -> str:
@@ -152,13 +171,16 @@ def mangle(filename: str) -> str:
     return base.replace('.', '_').replace('-', '_')
 
 
-def char2entity(c):
+def char2entity(c: str | bytes | bytearray) -> str:
     cp = ord(c)
     name = htmlentitydefs.codepoint2name.get(cp)
     return '&%s;' % name if name is not None else '&#%d;' % cp
 
 
-def substitute_entity(match, n2cp=htmlentitydefs.name2codepoint):
+def substitute_entity(
+    match: re.Match[str],
+    n2cp: Mapping[str, int] = htmlentitydefs.name2codepoint
+) -> str:
     ent = match.group(3)
 
     if match.group(1) == "#":
@@ -166,6 +188,10 @@ def substitute_entity(match, n2cp=htmlentitydefs.name2codepoint):
             return chr(int(ent))
         elif match.group(2) == 'x':
             return chr(int('0x' + ent, 16))
+        else:
+            # FIXME: This should be unreachable, so we can
+            #        try raising an AssertionError instead
+            return ''
     else:
         cp = n2cp.get(ent)
 
@@ -175,7 +201,12 @@ def substitute_entity(match, n2cp=htmlentitydefs.name2codepoint):
             return match.group()
 
 
-def create_formatted_exception(exc, cls, formatter, base=Exception):
+def create_formatted_exception(
+    exc: BaseException,
+    cls: type[object],
+    formatter: Callable[..., str],
+    base: type[BaseException] = Exception
+) -> BaseException:
     try:
         try:
             new = type(cls.__name__, (cls, base), {
@@ -187,13 +218,14 @@ def create_formatted_exception(exc, cls, formatter, base=Exception):
         except TypeError:
             new = cls
 
+        inst: BaseException
         try:
             inst = BaseException.__new__(new)
         except TypeError:
             inst = cls.__new__(new)
 
         BaseException.__init__(inst, *exc.args)
-        inst.__dict__ = exc.__dict__
+        inst.__dict__ = exc.__dict__  # type: ignore[attr-defined]
 
         return inst
     except ValueError:
@@ -230,7 +262,7 @@ def join(stream: Iterable[str]) -> str:
         raise
 
 
-def decode_htmlentities(string):
+def decode_htmlentities(string: str) -> str:
     """
     >>> str(decode_htmlentities('&amp;amp;'))
     '&amp;'
@@ -244,21 +276,21 @@ def decode_htmlentities(string):
 
 
 # Taken from zope.dottedname
-def _resolve_dotted(name, module=None):
-    name = name.split('.')
-    if not name[0]:
+def _resolve_dotted(name: str, module: str | None = None) -> Any:
+    name_parts = name.split('.')
+    if not name_parts[0]:
         if module is None:
             raise ValueError("relative name without base module")
-        module = module.split('.')
-        name.pop(0)
+        module_parts = module.split('.')
+        name_parts.pop(0)
         while not name[0]:
-            module.pop()
-            name.pop(0)
-        name = module + name
+            module_parts.pop()
+            name_parts.pop(0)
+        name_parts = module_parts + name_parts
 
-    used = name.pop(0)
+    used = name_parts.pop(0)
     found = __import__(used)
-    for n in name:
+    for n in name_parts:
         used += '.' + n
         try:
             found = getattr(found, n)
@@ -269,33 +301,36 @@ def _resolve_dotted(name, module=None):
     return found
 
 
-def resolve_dotted(dotted):
+def resolve_dotted(dotted: str) -> Any:
     if dotted not in module_cache:
         resolved = _resolve_dotted(dotted)
         module_cache[dotted] = resolved
     return module_cache[dotted]
 
 
-def limit_string(s, max_length=53):
+def limit_string(s: str, max_length: int = 53) -> str:
     if len(s) > max_length:
         return s[:max_length - 3] + '...'
 
     return s
 
 
-def value_repr(value):
+def value_repr(value: object) -> str:
     if isinstance(value, str):
         short = limit_string(value)
         return short.replace('\n', '\\n')
     if isinstance(value, (int, float)):
-        return value
+        return value  # type: ignore[return-value]
     if isinstance(value, dict):
         return '{...} (%d)' % len(value)
 
     try:
+        # FIXME: Is this trailing comma intentional?
+        #        it changes the formatting <foo (bar,) at ...>
+        #        vs. <foo bar at ...>
         name = str(getattr(value, '__name__', None)),
     except:  # noqa: E722 do not use bare 'except'
-        name = '-'
+        name = '-'  # type: ignore[assignment]
 
     return '<{} {} at {}>'.format(
         type(value).__name__, name, hex(abs(id(value))))
@@ -304,41 +339,41 @@ def value_repr(value):
 class callablestr(str):
     __slots__ = ()
 
-    def __call__(self):
+    def __call__(self) -> str:
         return self
 
 
 class callableint(int):
     __slots__ = ()
 
-    def __call__(self):
+    def __call__(self) -> int:
         return self
 
 
 class descriptorstr:
     __slots__ = "function", "__name__"
 
-    def __init__(self, function) -> None:
+    def __init__(self, function: Callable[[Any], str]) -> None:
         self.function = function
         self.__name__ = function.__name__
 
-    def __get__(self, context, cls):
+    def __get__(self, context: object, cls: type[object]) -> callablestr:
         return callablestr(self.function(context))
 
 
 class descriptorint:
     __slots__ = "function", "__name__"
 
-    def __init__(self, function) -> None:
+    def __init__(self, function: Callable[[Any], int]) -> None:
         self.function = function
         self.__name__ = function.__name__
 
-    def __get__(self, context, cls):
+    def __get__(self, context: object, cls: type[object]) -> callableint:
         return callableint(self.function(context))
 
 
 class DebuggingOutputStream(list[str]):
-    def append(self, value):
+    def append(self, value: str) -> None:
         if not isinstance(value, str):
             raise TypeError(value)
 
@@ -381,31 +416,36 @@ class Scope(dict[str, Any]):
 
     set_local = dict.__setitem__
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         value = self.get(key, marker)
         if value is marker:
             raise KeyError(key)
         return value
 
-    def __contains__(self, key) -> bool:
-        return self.get(key, marker) is not marker
+    def __contains__(self, key: object) -> bool:
+        return self.get(key, marker) is not marker  # type: ignore
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         root = getattr(self, "_root", marker)
-        yield from dict.__iter__(self)
+        yield from super().__iter__()
         if root is not marker:
             for key in root:
-                if not dict.__contains__(self, key):
+                if not super().__contains__(key):
                     yield key
 
-    def get(self, key, default=None):
-        value = dict.get(self, key, marker)
+    @overload
+    def get(self, key: str, default: None = None) -> Any | None: ...
+    @overload
+    def get(self, key: str, default: object) -> Any: ...
+
+    def get(self, key: str, default: object = None) -> Any:
+        value = super().get(key, marker)
         if value is not marker:
             return value
 
         root = getattr(self, "_root", marker)
         if root is not marker:
-            value = dict.get(root, key, marker)
+            value = super(Scope, root).get(key, marker)
 
             if value is not marker:
                 return value
@@ -413,20 +453,20 @@ class Scope(dict[str, Any]):
         return default
 
     @property
-    def vars(self):
+    def vars(self) -> Mapping[str, Any]:
         return self
 
-    def copy(self):
+    def copy(self) -> Scope:
         inst = Scope(self)
         root = getattr(self, "_root", self)
-        inst._root = root
+        inst._root = root  # type: ignore[attr-defined]
         return inst
 
-    def set_global(self, name, value) -> None:
+    def set_global(self, name: str, value: Any) -> None:
         root = getattr(self, "_root", self)
         root[name] = value
 
-    def get_name(self, key):
+    def get_name(self, key: str) -> Any:
         value = self.get(key, marker)
         if value is marker:
             raise NameError(key)
@@ -436,11 +476,14 @@ class Scope(dict[str, Any]):
     setGlobal = set_global
 
 
-class ListDictProxy:
-    def __init__(self, _l) -> None:
+class ListDictProxy(Generic[_KT, _VT_co]):
+    def __init__(
+        self: ListDictProxy[_KT, _VT_co],
+        _l: Sequence[Mapping[_KT, _VT_co]]
+    ) -> None:
         self._l = _l
 
-    def get(self, key):
+    def get(self, key: _KT) -> _VT_co | None:
         return self._l[-1].get(key)
 
 
@@ -471,12 +514,14 @@ class ImportableMarker:
         return '<%s>' % self.name
 
 
-def lookup_attr(obj, key):
+def lookup_attr(obj: object, key: str) -> Any:
     try:
         return getattr(obj, key)
     except AttributeError as exc:
+        # FIXME: What are the two try excepts here for?
+        #        We just raise the thing we catch...
         try:
-            get = obj.__getitem__
+            get = obj.__getitem__  # type: ignore[index]
         except AttributeError:
             raise exc
         try:

--- a/src/chameleon/zpt/loader.py
+++ b/src/chameleon/zpt/loader.py
@@ -12,7 +12,6 @@ from chameleon.zpt import template
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Sequence
-
     from typing_extensions import TypeAlias
 
     _FormatsMapping: TypeAlias = Mapping[str, type[template.PageTemplateFile]]

--- a/src/chameleon/zpt/loader.py
+++ b/src/chameleon/zpt/loader.py
@@ -1,10 +1,21 @@
-import typing as t
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Literal
+from typing import overload
 
 from chameleon.loader import TemplateLoader as BaseLoader
 from chameleon.zpt import template
 
 
-_FormatsMapping = t.Mapping[str, t.Type[template.PageTemplateFile]]
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from collections.abc import Sequence
+
+    from typing_extensions import TypeAlias
+
+    _FormatsMapping: TypeAlias = Mapping[str, type[template.PageTemplateFile]]
 
 
 class TemplateLoader(BaseLoader):
@@ -13,14 +24,14 @@ class TemplateLoader(BaseLoader):
         "text": template.PageTextTemplateFile,
     }
 
-    default_format: t.Literal['xml'] = "xml"
+    default_format: Literal['xml'] = "xml"
 
     def __init__(
         self,
-        search_path: t.Union[t.Sequence[str], str, None] = None,
+        search_path: Sequence[str] | str | None = None,
         *,
-        formats: t.Optional[_FormatsMapping] = None,
-        **kwargs: t.Any
+        formats: _FormatsMapping | None = None,
+        **kwargs: Any
     ) -> None:
 
         if formats is not None:
@@ -28,21 +39,21 @@ class TemplateLoader(BaseLoader):
 
         super().__init__(search_path, **kwargs)
 
-    @t.overload  # type: ignore[override]
+    @overload  # type: ignore[override]
     def load(
         self,
         filename: str,
-        format: t.Union[None, t.Literal['xml']] = None
+        format: Literal['xml'] | None = None
     ) -> template.PageTemplateFile: ...
 
-    @t.overload
+    @overload
     def load(
         self,
         filename: str,
-        format: t.Literal['text']
+        format: Literal['text']
     ) -> template.PageTextTemplateFile: ...
 
-    @t.overload
+    @overload
     def load(
         self,
         filename: str,
@@ -52,7 +63,7 @@ class TemplateLoader(BaseLoader):
     def load(
         self,
         filename: str,
-        format: t.Union[str, None] = None
+        format: str | None = None
     ) -> template.PageTemplateFile:
         """Load and return a template file.
 

--- a/src/chameleon/zpt/loader.py
+++ b/src/chameleon/zpt/loader.py
@@ -1,23 +1,59 @@
+import typing as t
+
 from chameleon.loader import TemplateLoader as BaseLoader
 from chameleon.zpt import template
 
 
+_FormatsMapping = t.Mapping[str, t.Type[template.PageTemplateFile]]
+
+
 class TemplateLoader(BaseLoader):
-    formats = {
+    formats: _FormatsMapping = {
         "xml": template.PageTemplateFile,
         "text": template.PageTextTemplateFile,
     }
 
-    default_format = "xml"
+    default_format: t.Literal['xml'] = "xml"
 
-    def __init__(self, *args, **kwargs):
-        formats = kwargs.pop('formats', None)
+    def __init__(
+        self,
+        search_path: t.Union[t.Sequence[str], str, None] = None,
+        *,
+        formats: t.Optional[_FormatsMapping] = None,
+        **kwargs: t.Any
+    ) -> None:
+
         if formats is not None:
             self.formats = formats
 
-        super().__init__(*args, **kwargs)
+        super().__init__(search_path, **kwargs)
 
-    def load(self, filename, format=None):
+    @t.overload  # type: ignore[override]
+    def load(
+        self,
+        filename: str,
+        format: t.Union[None, t.Literal['xml']] = None
+    ) -> template.PageTemplateFile: ...
+
+    @t.overload
+    def load(
+        self,
+        filename: str,
+        format: t.Literal['text']
+    ) -> template.PageTextTemplateFile: ...
+
+    @t.overload
+    def load(
+        self,
+        filename: str,
+        format: str
+    ) -> template.PageTemplateFile: ...
+
+    def load(
+        self,
+        filename: str,
+        format: t.Union[str, None] = None
+    ) -> template.PageTemplateFile:
         """Load and return a template file.
 
         The format parameter determines will parse the file. Valid

--- a/src/chameleon/zpt/program.py
+++ b/src/chameleon/zpt/program.py
@@ -1,12 +1,7 @@
 import re
 
-
-try:
-    str = unicode
-except NameError:
-    long = int
-
 import ast
+import typing as t
 from copy import copy
 from functools import partial
 
@@ -29,12 +24,6 @@ from chameleon.namespaces import XMLNS_NS
 from chameleon.program import ElementProgram
 from chameleon.utils import ImportableMarker
 from chameleon.utils import decode_htmlentities
-
-
-try:
-    str = unicode
-except NameError:
-    long = int
 
 
 missing = object()
@@ -63,7 +52,7 @@ def validate_attributes(attributes, namespace, whitelist):
             )
 
 
-def convert_data_attributes(ns_attrs, attrs, namespaces):
+def convert_data_attributes(ns_attrs, attrs, namespaces) -> None:
     d = 0
     for i, attr in list(enumerate(attrs)):
         name = attr['name']
@@ -114,13 +103,13 @@ class MacroProgram(ElementProgram):
     # Attributes which should have boolean behavior (on true, the
     # value takes the attribute name, on false, the attribute is
     # dropped)
-    boolean_attributes = set()
+    boolean_attributes: t.Set[str] = set()
 
     # If provided, this should be a set of attributes for implicit
     # translation. Any attribute whose name is included in the set
     # will be translated even without explicit markup. Note that all
     # values should be lowercase strings.
-    implicit_i18n_attributes = set()
+    implicit_i18n_attributes: t.Set[str] = set()
 
     # If set, text will be translated even without explicit markup.
     implicit_i18n_translate = False

--- a/src/chameleon/zpt/program.py
+++ b/src/chameleon/zpt/program.py
@@ -1,6 +1,5 @@
-import re
-
 import ast
+import re
 import typing as t
 from copy import copy
 from functools import partial

--- a/src/chameleon/zpt/program.py
+++ b/src/chameleon/zpt/program.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import ast
 import re
-import typing as t
 from copy import copy
 from functools import partial
 
@@ -102,13 +103,13 @@ class MacroProgram(ElementProgram):
     # Attributes which should have boolean behavior (on true, the
     # value takes the attribute name, on false, the attribute is
     # dropped)
-    boolean_attributes: t.Set[str] = set()
+    boolean_attributes: set[str] = set()
 
     # If provided, this should be a set of attributes for implicit
     # translation. Any attribute whose name is included in the set
     # will be translated even without explicit markup. Note that all
     # values should be lowercase strings.
-    implicit_i18n_attributes: t.Set[str] = set()
+    implicit_i18n_attributes: set[str] = set()
 
     # If set, text will be translated even without explicit markup.
     implicit_i18n_translate = False

--- a/src/chameleon/zpt/template.py
+++ b/src/chameleon/zpt/template.py
@@ -25,13 +25,13 @@ from chameleon.zpt.program import MacroProgram
 
 
 if t.TYPE_CHECKING:
-    from _typeshed import StrPath
     import typing_extensions as te
+    from _typeshed import StrPath
 
+    from chameleon.types import AnyTranslationFunction
     from chameleon.types import ExpressionType
     from chameleon.types import PageTemplateConfig
     from chameleon.types import Tokenizer
-    from chameleon.types import AnyTranslationFunction
 
 
 BOOLEAN_HTML_ATTRIBUTES = [

--- a/src/chameleon/zpt/template.py
+++ b/src/chameleon/zpt/template.py
@@ -28,11 +28,10 @@ from chameleon.zpt.program import MacroProgram
 
 
 if TYPE_CHECKING:
+    from _typeshed import StrPath
     from collections.abc import Callable
     from collections.abc import Collection
     from collections.abc import Iterable
-
-    from _typeshed import StrPath
     from typing_extensions import Unpack
 
     from chameleon.types import AnyTranslationFunction
@@ -216,8 +215,8 @@ class PageTemplate(BaseTemplate):
         # so it is itself not callable, we don't really care, since we only
         # ever use it as a descriptor, but to be able to override this with
         # an instance attribute we can't declare this as a descriptor and
-        # since we only need this ignore in 3.8 and 3.9 we will get an unused
-        # ignore error instead above
+        # since we only need this ignore in 3.9 we will get an unused ignore
+        # error instead above, so we use this version check to avoid that
         translate = staticmethod(simple_translate)  # type: ignore[assignment]
 
     encoding: str | None = None

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
     pypy3
     docs
     coverage
-
+    mypy
 [testenv]
 usedevelop = true
 deps =
@@ -93,3 +93,18 @@ exclude_lines =
 
 [coverage:html]
 directory = parts/htmlcov
+
+[testenv:mypy]
+basepython = python3
+skip_install = true
+commands_pre =
+deps =
+    mypy
+    importlib_resources
+    importlib_metadata
+commands =
+    mypy -p chameleon --python-version 3.8
+    mypy -p chameleon --python-version 3.9
+    mypy -p chameleon --python-version 3.10
+    mypy -p chameleon --python-version 3.11
+    mypy -p chameleon --python-version 3.12

--- a/tox.ini
+++ b/tox.ini
@@ -90,6 +90,8 @@ exclude_lines =
     if __name__ == '__main__':
     self.fail
     raise AssertionError
+    if TYPE_CHECKING:
+    assert_never
 
 [coverage:html]
 directory = parts/htmlcov

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@
 minversion = 3.18
 envlist =
     lint
-    py38
     py39
     py310
     py311
@@ -38,6 +37,7 @@ deps =
     check-python-versions >= 0.19.1
     wheel
     flake8
+    flake8-type-checking
     isort
 
 [testenv:isort-apply]
@@ -100,10 +100,8 @@ skip_install = true
 commands_pre =
 deps =
     mypy
-    importlib_resources
     importlib_metadata
 commands =
-    mypy -p chameleon --python-version 3.8
     mypy -p chameleon --python-version 3.9
     mypy -p chameleon --python-version 3.10
     mypy -p chameleon --python-version 3.11


### PR DESCRIPTION
Closes #405 

I tried to keep the diff relatively small, but I also wanted to enable a relatively strict mypy config for the public API, so I ended up annotating a bit more to guarantee a robust basis.

I also ran autotyping once which uses black to auto format the code, so there are a few formatting changes that have nothing to do with type annotations, but I made sure to revert most of them, to keep the diff as small as possible.

I also removed some of the leftover Python 2.7 compatibility stuff in the places where mypy wasn't happy about it.

I added a mypy environment to the tox config and added it to the matrix for github actions.

This also adds a minimal `pyproject.toml`. Some of the tool configuration could be moved from `setup.cfg` to `pyproject.toml` but for now it's probably not worth the effort, especially since flake8 doesn't support `pyproject.toml` yet and tox only sort of supports it by pasting the entire `tox.ini` in a multiline string inside the `pyproject.toml`.