### PR TITLE
Add 'z3c.macro' and 'z3c.pt' test suites to tox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,9 @@ jobs:
         - ["pypy-3.9", "pypy3"]
         - ["3.9",   "docs"]
         - ["3.9",   "coverage"]
-        - ["3.12",   "mypy"]
-
+        - ["3.12",  "mypy"]
+        - ["3.11",  "z3c.macro"]
+        - ["3.11",  "z3c.pt"]
     runs-on: ${{ matrix.os[1] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,9 @@ envlist =
     docs
     coverage
     mypy
+    z3c.macro
+    z3c.pt
+
 [testenv]
 usedevelop = true
 deps =
@@ -110,3 +113,25 @@ commands =
     mypy -p chameleon --python-version 3.10
     mypy -p chameleon --python-version 3.11
     mypy -p chameleon --python-version 3.12
+
+[testenv:z3c.macro]
+basepython = python3
+skip_install = true
+commands_pre =
+    pip install -e.
+usedevelop = true
+deps =
+    z3c.macro[test]
+commands =
+    zope-testrunner --path .tox/z3c.macro/lib/python3.11/site-packages --path . -s z3c.macro {posargs:-vc}
+
+[testenv:z3c.pt]
+basepython = python3
+skip_install = true
+commands_pre =
+    pip install -e.
+usedevelop = true
+deps =
+    z3c.pt[test]
+commands =
+    zope-testrunner --path .tox/z3c.pt/lib/python3.11/site-packages --path . -s z3c.pt {posargs:-vc}

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,7 @@ usedevelop = true
 deps =
     z3c.macro[test]
 commands =
-    zope-testrunner --path .tox/z3c.macro/lib/python3.11/site-packages --path . -s z3c.macro {posargs:-vc}
+    zope-testrunner --path {env_site_packages_dir} --path . -s z3c.macro {posargs:-vc}
 
 [testenv:z3c.pt]
 basepython = python3
@@ -134,4 +134,4 @@ usedevelop = true
 deps =
     z3c.pt[test]
 commands =
-    zope-testrunner --path .tox/z3c.pt/lib/python3.11/site-packages --path . -s z3c.pt {posargs:-vc}
+    zope-testrunner --path {env_site_packages_dir} --path . -s z3c.pt {posargs:-vc}


### PR DESCRIPTION
We want to make sure that a Chameleon release is compatible with the ecosystem.

We'll run the test suites of some of the more used packages.