### PR TITLE
Improves mypy config. Adds explicit re-exports to `__init__.py`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
 # we may want to include tests eventually
 exclude = "/tests/"
 follow_imports = "silent"
+warn_redundant_casts = true
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_return_any = true
 
 [[tool.mypy.overrides]]
 # strict config for fully typed modules and public API
@@ -23,7 +27,9 @@ disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_decorators = true
-warn_unused_ignores = true
+no_implicit_reexport = true
+strict_equality = true
+extra_checks = true
 
 [[tool.mypy.overrides]]
 module = ["zope.*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,6 @@ universal = 0
 [flake8]
 doctests = 1
 extend-select = TC1
-# F401 imported but unused
-per-file-ignores =
-    src/chameleon/__init__.py: F401
 
 [check-manifest]
 ignore =

--- a/src/chameleon/__init__.py
+++ b/src/chameleon/__init__.py
@@ -4,3 +4,13 @@ from chameleon.zpt.template import PageTemplate
 from chameleon.zpt.template import PageTemplateFile
 from chameleon.zpt.template import PageTextTemplate
 from chameleon.zpt.template import PageTextTemplateFile
+
+
+__all__ = (
+    'TemplateError',
+    'PageTemplateLoader',
+    'PageTemplate',
+    'PageTemplateFile',
+    'PageTextTemplate',
+    'PageTextTemplateFile',
+)

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -66,7 +66,7 @@ def identifier(prefix: str, suffix: str | None = None) -> str:
     return "__{}_{}".format(prefix, mangle(suffix or id(prefix)))
 
 
-def mangle(string: object) -> str:
+def mangle(string: int | str) -> str:
     return RE_MANGLE.sub('_', str(string)).replace('\n', '').replace('-', '_')
 
 

--- a/src/chameleon/i18n.py
+++ b/src/chameleon/i18n.py
@@ -69,11 +69,11 @@ else:   # pragma: no cover
             return None
 
         if target_language is not None or context is not None:
-            result = translate(
+            result: str = translate(
                 msgid, domain=domain, mapping=mapping, context=context,
                 target_language=target_language, default=default)
             if result != msgid:
-                return result  # type: ignore[no-any-return]
+                return result
 
         if isinstance(msgid, Message):
             default = msgid.default

--- a/src/chameleon/template.py
+++ b/src/chameleon/template.py
@@ -342,7 +342,7 @@ class BaseTemplate:
             builtins=builtins,
             strict=self.strict
         )
-        return compiler.code
+        return compiler.code  # type: ignore[no-any-return]
 
 
 class BaseTemplateFile(BaseTemplate):


### PR DESCRIPTION
`mypy --strict` will complain if Chameleon does not have explicit re-exports, so as a good citizen of the typing ecosystem we should add them, other people should not have to ignore re-export errors on our behalf. Since the module structure of Chameleon is fairly simple, this shouldn't add any real maintenance burden, since the top-level `__init__.py` file is the only one that re-exports imported symbols. We can also get rid of the flake8 per-file-ignores for `__init__.py` this way.

While I was at it I also increased the strictness of the strict config to match `mypy --strict`, as well as enabled most of the optional warnings. I also added some missing annotations while dealing with the new `warn-return-any` errors. Once everything is annotated and using the strict config, we can simplify most of the config back down to just `strict = true`.