### PR TITLE
Fix issue where macro would not get correctly rendered for a translation name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,9 @@ Changes
 
 In next release ...
 
--
+- Fix a bug where a macro could not be used correctly to render a
+  translation name.
+  (`#419 <https://github.com/malthe/chameleon/issues/419>`_)
 
 4.5.2 (2024-01-29)
 ------------------

--- a/src/chameleon/compiler.py
+++ b/src/chameleon/compiler.py
@@ -1703,7 +1703,7 @@ class Compiler:
 
         # generate code
         code = self.visit(node.node)
-        body.append(TranslationContext(code, append))
+        body.append(TranslationContext(code, append, stream))
 
         # output msgid
         text = Text('${%s}' % node.name)

--- a/src/chameleon/tests/inputs/128-translation-macro-name.pt
+++ b/src/chameleon/tests/inputs/128-translation-macro-name.pt
@@ -1,0 +1,5 @@
+<a metal:define-macro="fancy-link" href="#">Fancy link</a>
+
+<tal:something i18n:translate="text_with_link">
+  Now follows a fancy link: <metal:fancy-link i18n:name="obj_link" use-macro="macros['fancy-link']" />
+</tal:something>

--- a/src/chameleon/tests/outputs/128-en.pt
+++ b/src/chameleon/tests/outputs/128-en.pt
@@ -1,0 +1,3 @@
+<a href="#">Fancy link</a>
+
+Now follows a fancy link: <a href="#">Fancy link</a> ('text_with_link' translation into 'en')

--- a/src/chameleon/tests/outputs/128.pt
+++ b/src/chameleon/tests/outputs/128.pt
@@ -1,0 +1,3 @@
+<a href="#">Fancy link</a>
+
+Now follows a fancy link: <a href="#">Fancy link</a>


### PR DESCRIPTION
This closes issue #419.