### PR TITLE
Fix load_module deprecation warnings for Python >= 3.10.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changes
 
 In next release ...
 
-- ...
+- Fix ``load_module`` deprecation warnings for Python >= 3.10.
 
 4.5.4 (2024-04-08)
 ------------------

--- a/src/chameleon/loader.py
+++ b/src/chameleon/loader.py
@@ -12,6 +12,8 @@ import sys
 import tempfile
 import warnings
 from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec
+from importlib.util import spec_from_loader
 from threading import RLock
 from typing import TYPE_CHECKING
 from typing import Any
@@ -222,7 +224,13 @@ class ModuleLoader:
         try:
             module = sys.modules.get(base)
             if module is None:
-                module = SourceFileLoader(base, filename).load_module()
+                loader = SourceFileLoader(base, filename)
+                spec = spec_from_loader(base, loader)
+                if spec is None:
+                    raise ModuleNotFoundError(f"{base} ({filename})")
+                module = module_from_spec(spec)
+                loader.exec_module(module)
+                sys.modules[base] = module
         finally:
             release_lock()
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     pytest
     setuptools
 commands =
-    pytest --doctest-modules
+    pytest --doctest-modules -W error:"the load_module":DeprecationWarning -W error:"zipimport.zipimporter.load_module":DeprecationWarning {posargs}
 extras =
     test
 setenv =


### PR DESCRIPTION
The lint and mypy errors are also on master. I guess newer mypy added some errors and the Python versions changed because of latest Python release since last run 6 months ago.