### PR TITLE
Fix ast deprecation warnings up to Python 3.13.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Changes
 
 In next release ...
 
+- Fix ``ast`` deprecation warnings up to Python 3.13.
+  (`#430 <https://github.com/malthe/chameleon/issues/430>`_)
+
 - Fix ``load_module`` deprecation warnings for Python >= 3.10.
 
 4.5.4 (2024-04-08)

--- a/docs/library.rst
+++ b/docs/library.rst
@@ -72,7 +72,7 @@ You can write such a compiler as a closure:
    def uppercase_expression(string):
        def compiler(target, engine):
            uppercased = self.string.uppercase()
-           value = ast.Str(uppercased)
+           value = ast.Constant(uppercased)
            return [ast.Assign(targets=[target], value=value)]
        return compiler
 

--- a/src/chameleon/astutil.py
+++ b/src/chameleon/astutil.py
@@ -45,7 +45,7 @@ def subscript(
 ) -> ast.Subscript:
     return ast.Subscript(
         value=value,
-        slice=ast.Index(value=ast.Str(s=name)),
+        slice=ast.Constant(name),
         ctx=ctx,
     )
 

--- a/src/chameleon/tales.py
+++ b/src/chameleon/tales.py
@@ -61,7 +61,7 @@ def transform_attribute(node):
         "lookup(object, name)",
         lookup=Symbol(lookup_attr),
         object=node.value,
-        name=ast.Str(s=node.attr),
+        name=ast.Constant(node.attr),
         mode="eval"
     )
 
@@ -266,7 +266,7 @@ class ImportExpr:
         value = template(
             "RESOLVE(NAME)",
             RESOLVE=Symbol(resolve_dotted),
-            NAME=ast.Str(s=string),
+            NAME=ast.Constant(string),
             mode="eval",
         )
         return [ast.Assign(targets=[target], value=value)]
@@ -428,7 +428,7 @@ class StringExpr:
     ...                 return [
     ...                     ast.Assign(
     ...                         targets=[target],
-    ...                         value=ast.Num(n=len(expression))
+    ...                         value=ast.Constant(len(expression))
     ...                     )]
     ...
     ...         return compiler
@@ -473,8 +473,6 @@ class ProxyExpr(TalesExpr):
                 func=load(self.name),
                 args=[target],
                 keywords=[],
-                starargs=None,
-                kwargs=None
             ))
         ]
 

--- a/src/chameleon/zpt/program.py
+++ b/src/chameleon/zpt/program.py
@@ -234,7 +234,7 @@ class MacroProgram(ElementProgram):
             macro_name = macro_name.rsplit('/', 1)[-1]
             inner = nodes.Define(
                 [nodes.Assignment(
-                    ["macroname"], Static(ast.Str(macro_name)), True)],
+                    ["macroname"], Static(ast.Constant(macro_name)), True)],
                 inner,
             )
             STATIC_ATTRIBUTES = None
@@ -592,7 +592,8 @@ class MacroProgram(ElementProgram):
                     nodes.Sequence(
                         [attr for attr in attributes if
                          isinstance(attr, nodes.Attribute) and
-                         isinstance(attr.expression, ast.Str)]
+                         isinstance(attr.expression, ast.Constant) and
+                         isinstance(attr.expression.value, str)]
                     )
                 )
                 if end_tag is None:
@@ -796,7 +797,7 @@ class MacroProgram(ElementProgram):
                 if boolean:
                     value = nodes.Replace(value, name)
             else:
-                default = ast.Str(s=text) if text is not None else None
+                default = ast.Constant(text) if text is not None else None
 
                 # If the expression is non-trivial, the attribute is
                 # dynamic (computed).
@@ -833,7 +834,7 @@ class MacroProgram(ElementProgram):
                 # here if there's one or more "computed" attributes
                 # (dynamic, from one or more dict values).
                 else:
-                    value = ast.Str(s=text)
+                    value = ast.Constant(text)
                     if msgid is missing and implicit_i18n:
                         msgid = text
 
@@ -855,7 +856,10 @@ class MacroProgram(ElementProgram):
                     filtering[-1],
                 )
 
-                if not isinstance(value, ast.Str):
+                if (
+                    not isinstance(value, ast.Constant)
+                    or not isinstance(value.value, str)
+                ):
                     # Always define a ``default`` alias for non-static
                     # expressions.
                     attribute = nodes.Define(

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     pytest
     setuptools
 commands =
-    pytest --doctest-modules -W error:"the load_module":DeprecationWarning -W error:"zipimport.zipimporter.load_module":DeprecationWarning {posargs}
+    pytest --doctest-modules -W error:"the load_module":DeprecationWarning -W error:"zipimport.zipimporter.load_module":DeprecationWarning -W error:"ast.":DeprecationWarning {posargs}
 extras =
     test
 setenv =
@@ -114,6 +114,7 @@ commands =
     mypy -p chameleon --python-version 3.10
     mypy -p chameleon --python-version 3.11
     mypy -p chameleon --python-version 3.12
+    mypy -p chameleon --python-version 3.13
 
 [testenv:z3c.macro]
 basepython = python3


### PR DESCRIPTION
Wasn't so trivial after all ...

The changes have less specific types than before, as all of ``ast.Num``, ``ast.Str`` and ``ast.Index`` become ``ast.Constant``. This has been the case since Python 3.9 and it worked fine. I added additional ``isinstance`` checks. Not sure those are required or even harmful for some usecases.

``Node.lineno`` can't be ``None``, but also can't be omitted. I added ``ast.copy_location`` and ``ast.fix_missing_locations`` calls, but I'm not sure they do the desired thing at each place, as I don't fully understand what the places they are used are actually doing.

For the ``visit_FunctionDef`` transformer I couldn't find a more elegant solution to fix mypy. The ``type_params`` doesn't seem to be required, as the tests work without, but the type definition (and docs) seems to say otherwise.