### PR TITLE
Calculate package digest on first use.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changes
 
 In next release ...
 
+- Improve startup time when no template is used.
+
 - Fix ``ast`` deprecation warnings up to Python 3.13.
   (`#430 <https://github.com/malthe/chameleon/issues/430>`_)
 

--- a/src/chameleon/template.py
+++ b/src/chameleon/template.py
@@ -69,10 +69,17 @@ def get_package_versions() -> list[tuple[str, str]]:
     return sorted(versions.items())
 
 
-pkg_digest = hashlib.sha1(__name__.encode('utf-8'))
-for name, version in get_package_versions():
-    pkg_digest.update(name.encode('utf-8'))
-    pkg_digest.update(version.encode('utf-8'))
+_pkg_digest = None
+
+
+def get_pkg_digest() -> hashlib._Hash:
+    global _pkg_digest
+    if _pkg_digest is None:
+        _pkg_digest = hashlib.sha1(__name__.encode('utf-8'))
+        for name, version in get_package_versions():
+            _pkg_digest.update(name.encode('utf-8'))
+            _pkg_digest.update(version.encode('utf-8'))
+    return _pkg_digest.copy()
 
 
 log = logging.getLogger('chameleon.template')
@@ -320,7 +327,7 @@ class BaseTemplate:
 
     def digest(self, body: str, names: Collection[str]) -> str:
         class_name = type(self).__name__.encode('utf-8')
-        sha = pkg_digest.copy()
+        sha = get_pkg_digest()
         sha.update(body.encode('utf-8', 'ignore'))
         sha.update(class_name)
         digest = sha.hexdigest()


### PR DESCRIPTION
This allows for faster startup times in case no template is used.

Helps with things like [``argcomplete``](https://pypi.org/project/argcomplete/) or faster responses for errors that happen before templates are used. In my project the calculation of ``pkg_digest`` takes almost one second. It might be possible to use something different then ``packages_distributions`` from ``importlib.metadata``, which is the slow part, but I couldn't find a suitable replacement.