### PR TITLE
Use lowercase package name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         python setup.py bdist_wheel
     - uses: actions/upload-artifact@v4
       with:
-        name: Chameleon
+        name: chameleon
         path: ./dist/
   test:
     strategy:


### PR DESCRIPTION
This fixes PEP 625 deprecation:

> In the future, PyPI will require all newly uploaded source distribution filenames to comply with [PEP 625](https://peps.python.org/pep-0625/). Any source distributions already uploaded will remain in place as-is and do not need to be updated.